### PR TITLE
Add a SplitMultinormal sampler and KSG estimator prototype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: isort/isort-action@master
-      - uses: psf/black@stable
-      - uses: actions/setup-python@v2
+      - name: Run isort check
+        uses: isort/isort-action@master
+      - name: Run black formatting check
+        uses: psf/black@stable
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - name: Install the module
         run: pip install ".[test]"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # BMI (Benchmarking Mutual Information)
 Mutual information estimators and benchmark.
 
+## Usage
+
+_The package is still in early development phase and the public API is very fluid. We hope it will stabilize in December 2022._
+
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ exclude = '''
 '''
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/bmi"
+addopts = "--cov=src/bmi -n 3"
 testpaths = [
     "tests",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,6 @@ pytest
 pytest-cov
 pytest-xdist
 pytype
+scipy
+scikit-learn
 sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ where=src
 test =
     pytest
     pytest-cov
+    pytest-xdist
 
 [pytype]
 inputs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ install_requires =
     jaxlib
     numpy
     pydantic
+    scipy
+    scikit-learn
 
 [options.packages.find]
 where=src

--- a/src/bmi/estimators/base.py
+++ b/src/bmi/estimators/base.py
@@ -1,0 +1,7 @@
+"""Base classes for the estimators."""
+
+
+class EstimatorNotFittedException(Exception):
+    """Exception raised when the estimator needs to be fitted first (to access some method)."""
+
+    pass

--- a/src/bmi/estimators/ksg.py
+++ b/src/bmi/estimators/ksg.py
@@ -2,10 +2,9 @@
 from typing import Sequence, cast
 
 import numpy as np
-from numpy.typing import ArrayLike
-from scipy.special import digamma as _DIGAMMA
-from sklearn.preprocessing import StandardScaler as _StandardScaler
-from sklearn.metrics import pairwise_distances as _pairwise_distances
+from numpy.typing import ArrayLike  # pytype: disable=import-error
+from scipy.special import digamma as _DIGAMMA  # pytype: disable=import-error
+from sklearn import metrics, preprocessing  # pytype: disable=import-error
 
 from bmi.estimators.base import EstimatorNotFittedException
 from bmi.interface import IMutualInformationPointEstimator
@@ -36,18 +35,23 @@ class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
 
         if len(x) != len(y):
             raise ValueError(f"Arrays have different length: {len(x)} != {len(y)}.")
+        if len(x) <= max(self._neighborhoods):
+            raise ValueError(
+                f"Maximum neighborhood used is {max(self._neighborhoods)} "
+                f"but the number of points provided is only {len(x)}."
+            )
 
         if self._standardize:
-            x: np.ndarray = _StandardScaler(copy=False).fit_transform(x)
-            y: np.ndarray = _StandardScaler(copy=False).fit_transform(y)
+            x: np.ndarray = preprocessing.StandardScaler(copy=False).fit_transform(x)
+            y: np.ndarray = preprocessing.StandardScaler(copy=False).fit_transform(y)
 
         digammas_dict = {k: [] for k in self._neighborhoods}
 
         n_points = np.shape(x)[0]
         for index in range(n_points):
             # Distances from x[index] to all the points:
-            distances_x = _pairwise_distances(x[None, index], x)[0, :]
-            distances_y = _pairwise_distances(y[None, index], y)[0, :]
+            distances_x = metrics.pairwise_distances(x[None, index], x)[0, :]
+            distances_y = metrics.pairwise_distances(y[None, index], y)[0, :]
 
             # In the product (XxY) space we use the maximum distance
             distances_z = np.maximum(distances_x, distances_y)
@@ -81,5 +85,5 @@ class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
 
     def estimate(self, x: ArrayLike, y: ArrayLike) -> float:
         self.fit(x, y)
-        predictions = np.array(self.get_predictions().values())
+        predictions = np.asarray(list(self.get_predictions().values()))
         return cast(float, np.mean(predictions))

--- a/src/bmi/estimators/ksg.py
+++ b/src/bmi/estimators/ksg.py
@@ -1,0 +1,86 @@
+"""Kraskov estimators."""
+from typing import Sequence, cast
+
+import numpy as np
+from numpy.typing import ArrayLike  # pytype: disable=import-error
+from scipy import special  # pytype: disable=import-error
+from sklearn import metrics, preprocessing  # pytype: disable=import-error
+
+from bmi.estimators.base import EstimatorNotFittedException
+from bmi.interface import IMutualInformationPointEstimator
+
+_DIGAMMA = special.digamma
+
+
+class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
+    """Ensemble estimator built using the first approximation (equation (8) in the paper)."""
+
+    def __init__(self, neighborhoods: Sequence[int] = (5, 10), standardize: bool = True) -> None:
+        """
+
+        Args:
+            neighborhoods: sequence of positive integers,
+              specifying the size of neighborhood for MI calculation
+            standardize: whether to standardize the data before MI calculation, by default true
+        """
+        if min(neighborhoods) < 1:
+            raise ValueError("Each neighborhood must be at least 1.")
+
+        self._neighborhoods = list(neighborhoods)
+        self._standardize = standardize
+
+        self._fitted = False
+        self._mi_dict = {k: None for k in neighborhoods}
+
+    def fit(self, x: ArrayLike, y: ArrayLike) -> None:
+        x, y = np.array(x), np.array(y)
+
+        if len(x) != len(y):
+            raise ValueError(f"Arrays have different length: {len(x)} != {len(y)}.")
+
+        if self._standardize:
+            x = preprocessing.StandardScaler(copy=False).fit_transform(x)
+            y = preprocessing.StandardScaler(copy=False).fit_transform(y)
+
+        digammas_dict = {k: [] for k in self._neighborhoods}
+
+        n_points = len(x)
+        for index in range(n_points):
+            # Distances from x[index] to all the points:
+            distances_x = metrics.pairwise_distances(x[None, index], x)[0, :]
+            distances_y = metrics.pairwise_distances(y[None, index], y)[0, :]
+
+            # In the product (XxY) space we use the maximum distance
+            distances_z = np.maximum(distances_x, distances_y)
+            # And we sort the point indices by being the closest to the considered one
+            closest_points = sorted(range(len(distances_z)), key=lambda i: distances_z[i])
+
+            for k in self._neighborhoods:
+                # Note that the points are 0-indexed and that the "0th neighbor"
+                # is the point itself (as distance(x, x) = 0 is the smallest possible)
+                # Hence, the kth neighbour is at index k
+                kth_neighbour = closest_points[k]
+                distance = distances_z[kth_neighbour]
+
+                # Don't include the `i`th point itself in n_x and n_y
+                n_x = (distances_x < distance).sum() - 1
+                n_y = (distances_y < distance).sum() - 1
+
+                digammas_per_point = _DIGAMMA(n_x + 1) + _DIGAMMA(n_y + 1)
+                digammas_dict[k].append(digammas_per_point)
+
+        for k, digammas in digammas_dict.items():
+            mi_estimate = _DIGAMMA(k) - np.mean(digammas) + _DIGAMMA(n_points)
+            self._mi_dict[k] = max(0.0, mi_estimate)
+
+        self._fitted = True
+
+    def get_predictions(self) -> dict[int, float]:
+        if not self._fitted:
+            raise EstimatorNotFittedException
+        return cast(dict[int, float], self._mi_dict.copy())
+
+    def estimate(self, x: ArrayLike, y: ArrayLike) -> float:
+        self.fit(x, y)
+        predictions = self.get_predictions().values()
+        return cast(float, np.mean(predictions))

--- a/src/bmi/interface.py
+++ b/src/bmi/interface.py
@@ -1,9 +1,22 @@
 """Most important interfaces of the package."""
 from abc import abstractmethod
-from typing import Any, Protocol
+from typing import Any, Protocol, Union
 
 import numpy as np
 from numpy.typing import ArrayLike  # pytype: disable=import-error
+
+# Because we want to use a type annotation from private JAX API,
+# we will wrap it into the try-except statement
+try:
+    from jax._src.prng import PRNGKeyArray  # pytype: disable=import-error
+except ImportError:
+
+    class PRNGKeyArray:
+        pass
+
+
+# This type can be used to annotate if PRNGKeyArray (for JAX sampling) is needed.
+KeyArray = Union[PRNGKeyArray, Any]  # pytype: disable=invalid-annotation
 
 
 class IMutualInformationPointEstimator(Protocol):
@@ -27,7 +40,7 @@ class ISampler(Protocol):
     """Interface for a distribution P(X, Y)."""
 
     @abstractmethod
-    def sample(self, n_points: int, rng: Any) -> tuple[np.ndarray, np.ndarray]:
+    def sample(self, n_points: int, rng: KeyArray) -> tuple[np.ndarray, np.ndarray]:
         """Returns a sample from the joint distribution P(X, Y).
 
         Args:

--- a/src/bmi/interface.py
+++ b/src/bmi/interface.py
@@ -1,6 +1,6 @@
 """Most important interfaces of the package."""
-from typing import Any, Protocol
 from abc import abstractmethod
+from typing import Any, Protocol
 
 import numpy as np
 from numpy.typing import ArrayLike  # pytype: disable=import-error
@@ -8,7 +8,7 @@ from numpy.typing import ArrayLike  # pytype: disable=import-error
 
 class IMutualInformationPointEstimator(Protocol):
     """Interface for the mutual information estimator."""
-    
+
     @abstractmethod
     def estimate(self, x: ArrayLike, y: ArrayLike) -> float:
         """A point estimate of MI(X; Y) from an i.i.d sample from the P(X, Y) distribution.
@@ -23,7 +23,7 @@ class IMutualInformationPointEstimator(Protocol):
         raise NotImplementedError
 
 
-class IDistribution(Protocol):
+class ISampler(Protocol):
     """Interface for a distribution P(X, Y)."""
 
     @abstractmethod

--- a/src/bmi/samplers/base.py
+++ b/src/bmi/samplers/base.py
@@ -12,7 +12,3 @@ class BaseSampler(ISampler):
             raise ValueError(f"X variable space must be of positive dimension. Was {dim_x}.")
         if dim_y < 1:
             raise ValueError(f"Y variable space must be of positive dimension. Was {dim_x}.")
-
-    @property
-    def dim_total(self) -> int:
-        return self.dim_x + self.dim_y

--- a/src/bmi/samplers/base.py
+++ b/src/bmi/samplers/base.py
@@ -1,0 +1,18 @@
+"""Partial implementation of the IDistribution interface, convenient to inherit from."""
+from bmi.interface import ISampler
+
+
+class BaseSampler(ISampler):
+    """Partial implementation of the IDistribution interface, convenient to inherit from."""
+
+    @staticmethod
+    def _validate_dimensions(dim_x: int, dim_y: int) -> None:
+        """Method used to validate dimensions."""
+        if dim_x < 1:
+            raise ValueError(f"X variable space must be of positive dimension. Was {dim_x}.")
+        if dim_y < 1:
+            raise ValueError(f"Y variable space must be of positive dimension. Was {dim_x}.")
+
+    @property
+    def dim_total(self) -> int:
+        return self.dim_x + self.dim_y

--- a/src/bmi/samplers/splitmultinormal.py
+++ b/src/bmi/samplers/splitmultinormal.py
@@ -8,7 +8,7 @@ from bmi.samplers.base import BaseSampler
 
 def _can_be_covariance(mat):
     """Checks if `mat` can be a covariance matrix (positive-definite and symmetric)."""
-    if mat != mat.transpose():
+    if np.all(mat != mat.transpose()):
         raise ValueError("Covariance matrix is not symmetric.")
 
     if not np.all(np.linalg.eigvals(mat) > 0):

--- a/src/bmi/samplers/splitmultinormal.py
+++ b/src/bmi/samplers/splitmultinormal.py
@@ -42,7 +42,7 @@ class _Multinormal:
             samples, shape (n_samples, dim)
         """
         return random.multivariate_normal(
-            key=key, mean=self._mean, cov=self._covariance, shape=(n_samples, self.dim)
+            key=key, mean=self._mean, cov=self._covariance, shape=(n_samples,)
         )
 
     @property

--- a/src/bmi/samplers/splitmultinormal.py
+++ b/src/bmi/samplers/splitmultinormal.py
@@ -1,0 +1,138 @@
+import numpy as np
+from jax import random  # pytype: disable=import-error
+from numpy.typing import ArrayLike  # pytype: disable=import-error
+
+from bmi.samplers.base import BaseSampler
+
+
+class _Multinormal:
+    """Auxiliary object for representing the multivariate normal distribution."""
+
+    def __init__(self, mean: ArrayLike, covariance: ArrayLike) -> None:
+        """
+        Args:
+            mean: mean vector of the distribution, shape (dim,)
+            covariance: covariance matrix of the distribution, shape (dim, dim)
+        """
+        # Mean and the covariance
+        self._mean = np.asarray(mean)
+        self._covariance = np.asarray(covariance)
+
+        # The determinant of the covariance, used to calculate
+        # the entropy
+        self._det_covariance: float = np.linalg.det(self._covariance)
+
+        # Dimensionality of the space
+        self._dim = self._mean.shape[0]
+
+        # Validate the shape
+        if self._covariance.shape != (self._dim, self._dim):
+            raise ValueError(
+                f"Covariance has shape {self._covariance.shape} rather than "
+                f"{(self._dim, self._dim)}."
+            )
+        # TODO(Pawel): Validate whether covariance is positive definite
+
+    def sample(self, n_samples: int, key: random.PRNGKeyArray) -> np.ndarray:
+        """Sample from the distribution.
+        Args:
+            n_samples: number of samples to generate
+            key: JAX key for the pseudorandom number generator
+        Returns:
+            samples, shape (n_samples, dim)
+        """
+        return random.multivariate_normal(
+            key=key, mean=self._mean, cov=self._covariance, shape=(n_samples, self.dim)
+        )
+
+    @property
+    def dim(self) -> int:
+        """The dimensionality."""
+        return self._dim
+
+    def entropy(self) -> float:
+        """Entropy in nats."""
+        return 0.5 * (np.log(self._det_covariance) + self.dim * (1 + np.log(2 * np.pi)))
+
+
+class SplitMultinormal(BaseSampler):
+    """Represents two multinormal variables.
+
+    Covariance matrix should have the block form:
+
+        Cov[XX] Cov[XY]
+        Cov[YX] Cov[YY]
+
+    where:
+      - Cov[XX] is the covariance matrix of X variable (shape (dim_x, dim_x)),
+      - Cov[YY] is the covariance of the Y variable (shape (dim_y, dim_y))
+      - Cov[XY] and Cov[YX] (being transposes of each other, as the matrix is symmetric,
+            of shapes (dim_x, dim_y) or transposed one)
+        describe the interaction between X and Y.
+    """
+
+    def __init__(self, *, dim_x: int, dim_y: int, mean: ArrayLike, covariance: ArrayLike) -> None:
+        """
+
+        Args:
+            dim_x: dimension of the X space
+            dim_y: dimension of the Y space
+            mean: mean vector, shape (n,) where n = dim_x + dim_y
+            covariance: covariance matrix, shape (n, n)
+        """
+        # Set dimensions of spaces corresponding to individual variables
+        self._validate_dimensions(dim_x=dim_x, dim_y=dim_y)
+        self._dim_x = dim_x
+        self._dim_y = dim_y
+
+        # Set mean and covariance
+        self._mean = np.array(mean)
+        self._covariance = np.array(covariance)
+        self._validate_shapes()
+
+        self._joint_distribution = _Multinormal(mean=self._mean, covariance=self._covariance)
+        self._x_distribution = _Multinormal(
+            mean=self._mean[:dim_x], covariance=self._covariance[:dim_x, :dim_x]
+        )
+        self._y_distribution = _Multinormal(
+            mean=self._mean[dim_x:], covariance=self._covariance[dim_x:, dim_x:]
+        )
+
+    def _validate_shapes(self) -> None:
+        n = self.dim_total
+
+        if self._mean.shape != (n,):
+            raise ValueError(f"Mean vector has wrong shape: {self._mean.shape} instead of ({n},).")
+        if self._covariance.shape != (n, n):
+            raise ValueError(
+                f"Covariance matrix has wrong shape: "
+                f"{self._covariance.shape} instead of ({n}, {n})."
+            )
+
+    @property
+    def dim_x(self) -> int:
+        return self._dim_x
+
+    @property
+    def dim_y(self) -> int:
+        return self._dim_y
+
+    def sample(self, n_points: int, rng: random.PRNGKeyArray) -> tuple[np.ndarray, np.ndarray]:
+        xy = self._joint_distribution.sample(n_samples=n_points, key=rng)
+        return xy[..., : self._dim_x], xy[..., self.dim_x :]  # noqa: E203
+
+    def mutual_information(self) -> float:
+        """Calculates the mutual information I(X; Y) using an exact formula.
+        Returns:
+            mutual information, in nats
+        The mutual information is given by
+            0.5 * log( det(covariance_x) * det(covariance_y) / det(full covariance) )
+        what follows from the
+            I(X; Y) = H(X) + H(Y) - H(X, Y)
+        formula and the entropy of the multinormal distribution.
+        """
+        h_x = self._x_distribution.entropy()
+        h_y = self._y_distribution.entropy()
+        h_xy = self._joint_distribution.entropy()
+        mi = h_x + h_y - h_xy  # Mutual information estimate
+        return max(0.0, mi)  # Mutual information is always non-negative

--- a/src/bmi/samplers/splitmultinormal.py
+++ b/src/bmi/samplers/splitmultinormal.py
@@ -6,6 +6,15 @@ from bmi.interface import KeyArray
 from bmi.samplers.base import BaseSampler
 
 
+def _can_be_covariance(mat):
+    """Checks if `mat` can be a covariance matrix (positive-definite and symmetric)."""
+    if mat != mat.transpose():
+        raise ValueError("Covariance matrix is not symmetric.")
+
+    if not np.all(np.linalg.eigvals(mat) > 0):
+        raise ValueError("Covariance matrix is not positive-definite.")
+
+
 class _Multinormal:
     """Auxiliary object for representing multivariate normal distributions."""
 

--- a/src/bmi/samplers/splitmultinormal.py
+++ b/src/bmi/samplers/splitmultinormal.py
@@ -1,23 +1,9 @@
 import numpy as np
-from jax import random
-from jax._src import prng
+from jax import random  # pytype: disable=import-error
+from numpy.typing import ArrayLike  # pytype: disable=import-error
 
-from numpy.typing import ArrayLike
-from typing import Any, Union
-
+from bmi.interface import KeyArray
 from bmi.samplers.base import BaseSampler
-
-
-KeyArray = Union[Any, prng.PRNGKeyArray]
-
-
-def _can_be_covariance(mat):
-    """Checks if `mat` can be a covariance matrix (positive-definite and symmetric)."""
-    if mat != mat.transpose():
-        raise ValueError("Covariance matrix is not symmetric.")
-
-    if not np.all(np.linalg.eigvals(mat) > 0):
-        raise ValueError("Covariance matrix is not positive-definite.")
 
 
 class _Multinormal:
@@ -57,9 +43,11 @@ class _Multinormal:
         Returns:
             samples, shape (n_samples, dim)
         """
-        return np.array(random.multivariate_normal(
-            key=key, mean=self._mean, cov=self._covariance, shape=(n_samples,)
-        ))
+        return np.array(
+            random.multivariate_normal(
+                key=key, mean=self._mean, cov=self._covariance, shape=(n_samples,)
+            )
+        )
 
     @property
     def dim(self) -> int:
@@ -118,13 +106,10 @@ class SplitMultinormal(BaseSampler):
         n = self.dim_total
 
         if self._mean.shape != (n,):
-            raise ValueError(
-                f"Mean vector has shape {self._mean.shape}, expected ({n},)."
-            )
+            raise ValueError(f"Mean vector has shape {self._mean.shape}, expected ({n},).")
         if self._covariance.shape != (n, n):
             raise ValueError(
-                f"Covariance matrix has shape {self._covariance.shape}, "
-                f"expected ({n}, {n})."
+                f"Covariance matrix has shape {self._covariance.shape}, " f"expected ({n}, {n})."
             )
 
     @property

--- a/src/bmi/samplers/splitmultinormal.py
+++ b/src/bmi/samplers/splitmultinormal.py
@@ -11,6 +11,15 @@ from bmi.samplers.base import BaseSampler
 KeyArray = Union[Any, prng.PRNGKeyArray]
 
 
+def _can_be_covariance(mat):
+    """Checks if `mat` can be a covariance matrix (positive-definite and symmetric)."""
+    if mat != mat.transpose():
+        raise ValueError("Covariance matrix is not symmetric.")
+
+    if not np.all(np.linalg.eigvals(mat) > 0):
+        raise ValueError("Covariance matrix is not positive-definite.")
+
+
 class _Multinormal:
     """Auxiliary object for representing multivariate normal distributions."""
 
@@ -36,7 +45,9 @@ class _Multinormal:
                 f"Covariance has shape {self._covariance.shape}, expected "
                 f"{(self._dim, self._dim)}."
             )
-        # TODO(Pawel): Validate whether covariance is positive definite
+
+        # Validate symmetry, positive-definiteness
+        _can_be_covariance(self._covariance)
 
     def sample(self, n_samples: int, key: KeyArray) -> np.ndarray:
         """Sample from the distribution.

--- a/tests/estimators/test_ksg.py
+++ b/tests/estimators/test_ksg.py
@@ -1,29 +1,31 @@
 import numpy as np
-import pytest
-from jax import random
+import pytest  # pytype: disable=import-error
+from jax import random  # pytype: disable=import-error
+from sklearn.feature_selection import mutual_info_regression  # pytype: disable=import-error
 
-import bmi.estimators.ksg as ksg
-from bmi.samplers.splitmultinormal import SplitMultinormal
+import bmi.estimators.ksg as ksg  # pytype: disable=import-error
+from bmi.samplers.splitmultinormal import SplitMultinormal  # pytype: disable=import-error
 
 
-def random_covariance(size: int, jitter: float = 1e1, rng=0):
+def random_covariance(size: int, jitter: float = 1e-2, rng=0):
     a = np.random.default_rng(rng).normal(0, 1, size=(size, size))
 
     return np.dot(a, a.T) + np.diag([jitter] * size)
 
 
 def test_digamma():
-    """Tests whether the digamma function used seems right."""
+    """Tests whether the digamma function we use seems right."""
     assert ksg._DIGAMMA(1) == pytest.approx(-0.5772156, abs=1e-5)
 
     for k in range(2, 5):
         assert ksg._DIGAMMA(k + 1) == pytest.approx(ksg._DIGAMMA(k) + 1 / k, rel=0.01)
 
 
-@pytest.mark.parametrize("n_points", [1000])
-@pytest.mark.parametrize("k", [5, 10])
-@pytest.mark.parametrize("correlation", [0.0, 0.6, 0.8, 0.9])
-def test_estimate_mi_ksg_known(n_points: int, k: int, correlation: float) -> None:
+@pytest.mark.parametrize("n_points", [200])
+@pytest.mark.parametrize("k", [10])
+@pytest.mark.parametrize("correlation", [0.0, 0.5, 0.8])
+def test_estimate_mi_ksg_2d(n_points: int, k: int, correlation: float) -> None:
+    """Simple tests for the KSG estimator with 2D Gaussian with known correlation."""
     covariance = np.array(
         [
             [1.0, correlation],
@@ -44,13 +46,14 @@ def test_estimate_mi_ksg_known(n_points: int, k: int, correlation: float) -> Non
 
     true_mi = distribution.mutual_information()
 
-    assert estimated_mi == pytest.approx(true_mi, rel=0.1, abs=0.05)
+    assert estimated_mi == pytest.approx(true_mi, rel=0.15, abs=0.12)
 
 
-@pytest.mark.parametrize("n_points", [500, 1000])
-@pytest.mark.parametrize("k", [5, 10])
-@pytest.mark.parametrize("dims", [(1, 1), (1, 2), (2, 2)])
-def test_estimate_mi_ksg(n_points: int, k: int, dims: tuple[int, int]) -> None:
+@pytest.mark.parametrize("n_points", [450])
+@pytest.mark.parametrize("k", [5])
+@pytest.mark.parametrize("dims", [(1, 2), (2, 2)])
+def test_estimate_mi_ksg_random_covariance(n_points: int, k: int, dims: tuple[int, int]) -> None:
+    """Tests whether the MI agrees for a random covariance."""
     dim_x, dim_y = dims
 
     distribution = SplitMultinormal(
@@ -68,7 +71,95 @@ def test_estimate_mi_ksg(n_points: int, k: int, dims: tuple[int, int]) -> None:
     true_mi = distribution.mutual_information()
 
     # Approximate the MI to 10% and take correction for very small values
-    assert estimated_mi == pytest.approx(true_mi, rel=0.1, abs=0.02)
+    assert estimated_mi == pytest.approx(true_mi, rel=0.15, abs=0.1)
 
 
-# TODO(Pawel): Test the fit methods.
+@pytest.mark.parametrize("difference", [0, 1, 5])
+def test_ksg_more_neighbors_than_points_raises(
+    difference: int, neighborhoods: tuple[int, ...] = (10,), dim: int = 3
+) -> None:
+    """Tests whether an exception is raised if the number of required neighbors
+    is greater than the number of points provided."""
+    n_points = max(neighborhoods) - difference  # We don't have enough data points
+    x = np.zeros((n_points, dim))
+
+    estimator = ksg.KSGEnsembleFirstEstimator(neighborhoods=neighborhoods)
+
+    with pytest.raises(ValueError):
+        estimator.fit(x, x)
+
+
+@pytest.mark.parametrize("neighborhoods", [(2, 5), (1, 10)])
+def test_ksg_fit_predict(neighborhoods: tuple[int, ...], n_samples: int = 15) -> None:
+    """Tests whether the estimator can be fitted
+    and if it allows to get the predictions afterwards."""
+
+    distribution = SplitMultinormal(
+        mean=np.zeros(2),
+        covariance=np.eye(2),
+        dim_x=1,
+        dim_y=1,
+    )
+
+    rng = random.PRNGKey(10)
+    x_sample, y_sample = distribution.sample(n_samples, rng=rng)
+
+    estimator = ksg.KSGEnsembleFirstEstimator(neighborhoods=neighborhoods)
+    estimator.fit(x_sample, y_sample)
+
+    predictions = estimator.get_predictions()
+
+    for k in neighborhoods:
+        assert predictions.get(k) is not None
+        assert predictions[k] >= 0
+
+    assert list(predictions.keys()) == list(neighborhoods)
+
+
+def test_ksg_predict_before_fit() -> None:
+    estimator = ksg.KSGEnsembleFirstEstimator()
+
+    with pytest.raises(ksg.EstimatorNotFittedException):
+        estimator.get_predictions()
+
+
+class TestKSGAgreesWithSKLearn:
+    """In this suite of tests we compare our implementation
+    with the implementation in Sci-Kit Learn, which works
+    for 1-D random variables.
+
+    We generate our 1-D random variables using an auxiliary random variable
+        U ~ N(0, 1)
+    and use (not necessarily injective) functions f, g: R -> R
+    to generate
+        X | U ~ f(U) + noise
+        Y | U ~ g(U) + noise
+    """
+
+    @pytest.mark.parametrize("n_samples", [50, 100, 200])
+    @pytest.mark.parametrize("noise", [1e-2, 1e-1])
+    def test_quadratic(
+        self, n_samples: int, noise: float, neighborhoods: tuple[int, ...] = (5, 10, 15)
+    ) -> None:
+        """In this test f(u) = u, g(u) = u**2 and we add Gaussian noise of magnitude `noise`."""
+        rng = random.PRNGKey(10)
+        rng_u, rng_noise_x, rng_noise_y = random.split(rng, 3)
+
+        # These matrices have shape (n_samples,)
+        u_sample = random.normal(rng_u, shape=(n_samples,))
+        x_sample = u_sample + noise * random.normal(rng_noise_x, shape=u_sample.shape)
+        y_sample = u_sample**2 + noise * random.normal(rng_noise_y, shape=u_sample.shape)
+
+        estimator = ksg.KSGEnsembleFirstEstimator(neighborhoods=neighborhoods, standardize=True)
+        # We need to provide matrices (n_samples, 1)
+        estimator.fit(x_sample[:, None], y_sample[:, None])
+        our_predictions = estimator.get_predictions()
+
+        for k in neighborhoods:
+            our_mi = our_predictions[k]
+            sklearn_mi = mutual_info_regression(
+                X=x_sample[:, None], y=y_sample, n_neighbors=k, random_state=0
+            )
+            assert our_mi == pytest.approx(
+                sklearn_mi, rel=0.01, abs=0.00
+            ), f"MI different: {our_mi} != {sklearn_mi}"

--- a/tests/estimators/test_ksg.py
+++ b/tests/estimators/test_ksg.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pytest  # pytype: disable=import-error
+from jax import random  # pytype: disable=import-error
+
+import bmi.estimators.ksg as ksg
+from bmi.samplers.splitmultinormal import SplitMultinormal
+
+
+def random_covariance(size: int, jitter: float = 1e1, rng=0):
+    a = np.random.default_rng(rng).normal(0, 1, size=(size, size))
+
+    return np.dot(a, a.T) + np.diag([jitter] * size)
+
+
+def test_digamma():
+    """Tests whether the digamma function used seems right."""
+    assert ksg._DIGAMMA(1) == pytest.approx(-0.5772156, abs=1e-5)
+
+    for k in range(2, 5):
+        assert ksg._DIGAMMA(k + 1) == pytest.approx(ksg._DIGAMMA(k) + 1 / k, rel=0.01)
+
+
+@pytest.mark.parametrize("n_points", [1000])
+@pytest.mark.parametrize("k", [5, 10])
+@pytest.mark.parametrize("correlation", [0.0, 0.6, 0.8, 0.9])
+def test_estimate_mi_ksg_known(n_points: int, k: int, correlation: float) -> None:
+    covariance = np.array(
+        [
+            [1.0, correlation],
+            [correlation, 1.0],
+        ]
+    )
+    distribution = SplitMultinormal(
+        dim_x=1,
+        dim_y=1,
+        mean=np.zeros(2),
+        covariance=covariance,
+    )
+    rng = random.PRNGKey(19)
+    points_x, points_y = distribution.sample(n_points, rng=rng)
+
+    estimator = ksg.KSGEnsembleFirstEstimator(neighborhoods=(k,), standardize=True)
+    estimated_mi = estimator.estimate(points_x, points_y)
+
+    true_mi = distribution.mutual_information()
+
+    assert estimated_mi == pytest.approx(true_mi, rel=0.1, abs=0.05)
+
+
+@pytest.mark.parametrize("n_points", [500, 1000])
+@pytest.mark.parametrize("k", [5, 10])
+@pytest.mark.parametrize("dims", [(1, 1), (1, 2), (2, 2)])
+def test_estimate_mi_ksg(n_points: int, k: int, dims: tuple[int, int]) -> None:
+    dim_x, dim_y = dims
+
+    distribution = SplitMultinormal(
+        dim_x=dim_x,
+        dim_y=dim_y,
+        mean=np.zeros(dim_x + dim_y),
+        covariance=random_covariance(dim_x + dim_y),
+    )
+
+    rng = random.PRNGKey(20)
+    points_x, points_y = distribution.sample(n_points, rng=rng)
+
+    estimator = ksg.KSGEnsembleFirstEstimator(neighborhoods=(k,), standardize=True)
+    estimated_mi = estimator.estimate(points_x, points_y)
+    true_mi = distribution.mutual_information()
+
+    # Approximate the MI to 10% and take correction for very small values
+    assert estimated_mi == pytest.approx(true_mi, rel=0.1, abs=0.02)
+
+
+# TODO(Pawel): Test the fit methods.

--- a/tests/estimators/test_ksg.py
+++ b/tests/estimators/test_ksg.py
@@ -1,6 +1,6 @@
 import numpy as np
-import pytest  # pytype: disable=import-error
-from jax import random  # pytype: disable=import-error
+import pytest
+from jax import random
 
 import bmi.estimators.ksg as ksg
 from bmi.samplers.splitmultinormal import SplitMultinormal

--- a/tests/samplers/test_splitmultinormal.py
+++ b/tests/samplers/test_splitmultinormal.py
@@ -1,21 +1,26 @@
 import numpy as np
-import pytest
-from jax import random
+import pytest  # pytype: disable=import-error
+from jax import random  # pytype: disable=import-error
 
-from bmi.samplers.splitmultinormal import SplitMultinormal
+from bmi.samplers.splitmultinormal import SplitMultinormal  # pytype: disable=import-error
 
 
 @pytest.mark.parametrize("y", (2, 5, 10))
 @pytest.mark.parametrize("x", (1, 2, 3))
 @pytest.mark.parametrize("variance", (0.5, 1, 2))
-def test_symmetric_gaussian(x: int, y: int, variance: float, n_samples: int = 2_000) -> None:
+def test_symmetric_gaussian_mi(x: int, y: int, variance: float, n_samples: int = 2_000) -> None:
     """Tests if the standard Gaussian has MI = 0."""
+
+    rng = random.PRNGKey(111)
+    rng, mean_rng = random.split(rng)
+
+    mean = random.uniform(mean_rng, shape=(x + y,))
 
     sampler = SplitMultinormal(
         dim_x=x,
         dim_y=y,
-        mean=np.zeros(x + y),
-        covariance=np.eye(x + y),
+        mean=mean,
+        covariance=variance * np.eye(x + y),
     )
 
     assert sampler.dim_x == x, f"x dim: {sampler.dim_x} != {x}"
@@ -25,7 +30,6 @@ def test_symmetric_gaussian(x: int, y: int, variance: float, n_samples: int = 2_
     sampler_mi = sampler.mutual_information()
     assert sampler_mi == pytest.approx(0, abs=1e-3), f"MI wrong: {sampler_mi} != 0"
 
-    rng = random.PRNGKey(111)
     x_sample, y_sample = sampler.sample(n_points=n_samples, rng=rng)
 
     assert x_sample.shape == (
@@ -44,5 +48,66 @@ def test_symmetric_gaussian(x: int, y: int, variance: float, n_samples: int = 2_
     ), f"XxY sample shape: {xy_sample.shape} != {(n_samples, x+y)}"
 
     assert np.allclose(
-        np.zeros(x + y), xy_sample.mean(axis=0), atol=0.1 * max(1, variance)
-    ), f"Arrays different: {np.zeros(x+y)} != {xy_sample.mean(axis=0)}"
+        mean, xy_sample.mean(axis=0), rtol=0.05, atol=0.07
+    ), f"Arrays different: {mean} != {xy_sample.mean(axis=0)}"
+
+
+@pytest.mark.parametrize("mean_xy", [(0.1, 0.4), (0.4, -0.9)])
+@pytest.mark.parametrize("std_xy", [(0.5, 1.0)])
+@pytest.mark.parametrize("correlation", [0.9, -0.5])
+def test_2d_gaussian(
+    mean_xy: tuple[float, float],
+    std_xy: tuple[float, float],
+    correlation: float,
+    n_samples: int = 1500,
+) -> None:
+    """Tests whether the samples from 2D Gaussian look right. We analyze both means
+    and the full covariance matrix.
+
+    Args:
+        mean_xy: tuple representing means of two 1D Gaussians: (mean_x, mean_y)
+        std_xy: tuple representing std of two 1D Gaussians: (std_x, std_y)
+        correlation: correlation between X and Y
+    """
+
+    var_x = std_xy[0] ** 2
+    var_y = std_xy[1] ** 2
+    cov_xy = std_xy[0] * std_xy[1] * correlation
+
+    mean = np.asarray(mean_xy)
+    covariance = np.asarray(
+        [
+            [var_x, cov_xy],
+            [cov_xy, var_y],
+        ]
+    )
+
+    sampler = SplitMultinormal(
+        dim_x=1,
+        dim_y=1,
+        mean=mean,
+        covariance=covariance,
+    )
+
+    rng = random.PRNGKey(10)
+    x_sample, y_sample = sampler.sample(n_samples, rng=rng)
+
+    assert x_sample.shape == (n_samples, 1), f"X shape wrong: {x_sample.shape}"
+    assert y_sample.shape == (n_samples, 1), f"Y shape wrong: {x_sample.shape}"
+
+    assert np.mean(x_sample) == pytest.approx(
+        mean_xy[0], rel=0.1, abs=0.03
+    ), f"X mean wrong: {np.mean(x_sample)} != {mean_xy[0]}"
+    assert np.mean(y_sample) == pytest.approx(
+        mean_xy[1], rel=0.1, abs=0.03
+    ), f"Y mean wrong: {np.mean(y_sample)} != {mean_xy[1]}"
+
+    assert np.std(x_sample) == pytest.approx(
+        std_xy[0], rel=0.1, abs=0.03
+    ), f"X std wrong: {np.std(x_sample)} != {std_xy[0]}"
+    assert np.std(y_sample) == pytest.approx(
+        std_xy[1], rel=0.1, abs=0.03
+    ), f"Y std wrong: {np.std(y_sample)} != {std_xy[1]}"
+
+    correlation_estimate = np.corrcoef(x_sample.ravel(), y_sample.ravel())[0, 1]
+    assert correlation_estimate == pytest.approx(correlation, rel=0.1)

--- a/tests/samplers/test_splitmultinormal.py
+++ b/tests/samplers/test_splitmultinormal.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest  # pytype: disable=import-error
+from jax import random  # pytype: disable=import-error
+
+from bmi.samplers.splitmultinormal import SplitMultinormal
+
+
+@pytest.mark.parametrize("y", (2, 5, 10))
+@pytest.mark.parametrize("x", (1, 2, 3))
+@pytest.mark.parametrize("variance", (0.5, 1, 2))
+def test_symmetric_gaussian(x: int, y: int, variance: float, n_samples: int = 2_000) -> None:
+    """Tests if the standard Gaussian has MI = 0."""
+
+    sampler = SplitMultinormal(
+        dim_x=x,
+        dim_y=y,
+        mean=np.zeros(x + y),
+        covariance=np.eye(x + y),
+    )
+
+    assert sampler.dim_x == x, f"x dim: {sampler.dim_x} != {x}"
+    assert sampler.dim_y == y, f"y dim: {sampler.dim_x} != {x}"
+    assert sampler.dim_total == x + y, f"total dim: {sampler.dim_total} != {x + y}"
+
+    sampler_mi = sampler.mutual_information()
+    assert sampler_mi == pytest.approx(0, abs=1e-3), f"MI wrong: {sampler_mi} != 0"
+
+    rng = random.PRNGKey(111)
+    x_sample, y_sample = sampler.sample(n_points=n_samples, rng=rng)
+
+    assert x_sample.shape == (
+        n_samples,
+        x,
+    ), f"X sample shape: {x_sample.shape} != {(n_samples, x)}"
+    assert y_sample.shape == (
+        n_samples,
+        y,
+    ), f"Y sample shape: {y_sample.shape} != {(n_samples, y)}"
+
+    xy_sample = np.hstack([x_sample, y_sample])
+    assert xy_sample.shape == (
+        n_samples,
+        x + y,
+    ), f"XxY sample shape: {xy_sample.shape} != {(n_samples, x+y)}"
+
+    assert np.allclose(
+        np.zeros(x + y), xy_sample.mean(axis=0), atol=0.1 * max(1, variance)
+    ), f"Arrays different: {np.zeros(x+y)} != {xy_sample.mean(axis=0)}"

--- a/tests/samplers/test_splitmultinormal.py
+++ b/tests/samplers/test_splitmultinormal.py
@@ -1,6 +1,6 @@
 import numpy as np
-import pytest  # pytype: disable=import-error
-from jax import random  # pytype: disable=import-error
+import pytest
+from jax import random
 
 from bmi.samplers.splitmultinormal import SplitMultinormal
 


### PR DESCRIPTION
We can start with a KSG estimator and the split multinormal sampler. The basic tests are included (of course, they could be extended).
Also, this PR fixes a bug in the build workflow (it used Python 3.8 instead of Python 3.9 and 3.10).

Unfortunately, this is not the smallest PR to review – I should have created a smaller PR with `SplitMultinormal` and then add KSG estimator in another one.

----

### Tasks
  - [x] Change name from `Distribution` to `Sampler`.
  - [x] Implement `SplitMultinormal` and test that it generates good samples.
  - [x] Implement KSG estimator based on eq. (8) from https://arxiv.org/abs/cond-mat/0305641
  - [x] Create unit tests to check whether KSG gives good results on `SplitMultinormal` samplers.
  - [x] Create unit tests to check whether this implementation of KSG agrees with SciKit Learn's for 1-dimensional $X$ and $Y$.
