### PR TITLE
Fix pre-commit pytype issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   rev: 22.3.0
   hooks:
     - id: black
-      language_version: python3.9
+      name: black (python)
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
   hooks:
     - id: pytype
       args: []
+      language: system
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort
+      name: isort (python)
 - repo: https://github.com/psf/black
   rev: 22.3.0
   hooks:
@@ -18,8 +23,3 @@ repos:
     - id: pytype
       args: []
       language: system
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
-  hooks:
-    - id: isort
-      name: isort (python)

--- a/src/bmi/estimators/ksg.py
+++ b/src/bmi/estimators/ksg.py
@@ -2,9 +2,9 @@
 from typing import Sequence, cast
 
 import numpy as np
-from numpy.typing import ArrayLike  # pytype: disable=import-error
-from scipy.special import digamma as _DIGAMMA  # pytype: disable=import-error
-from sklearn import metrics, preprocessing  # pytype: disable=import-error
+from numpy.typing import ArrayLike
+from scipy.special import digamma as _DIGAMMA
+from sklearn import metrics, preprocessing
 
 from bmi.estimators.base import EstimatorNotFittedException
 from bmi.interface import IMutualInformationPointEstimator

--- a/src/bmi/interface.py
+++ b/src/bmi/interface.py
@@ -1,12 +1,13 @@
 """Most important interfaces of the package."""
 from abc import abstractmethod
-from typing import Any, Protocol, Union
+from typing import Any, Protocol
 
 import numpy as np
 from numpy.typing import ArrayLike
 
-# This should be updated to PRNGKeyArray when it becomes a part of public JAX API
-KeyArray = Union[Any]
+# This should be updated to the PRNGKeyArray (or possibly union with Any)
+# when it becomes a part of public JAX API
+KeyArray = Any
 
 
 class IMutualInformationPointEstimator(Protocol):

--- a/src/bmi/interface.py
+++ b/src/bmi/interface.py
@@ -3,20 +3,10 @@ from abc import abstractmethod
 from typing import Any, Protocol, Union
 
 import numpy as np
-from numpy.typing import ArrayLike  # pytype: disable=import-error
+from numpy.typing import ArrayLike
 
-# Because we want to use a type annotation from private JAX API,
-# we will wrap it into the try-except statement
-try:
-    from jax._src.prng import PRNGKeyArray  # pytype: disable=import-error
-except ImportError:
-
-    class PRNGKeyArray:
-        pass
-
-
-# This type can be used to annotate if PRNGKeyArray (for JAX sampling) is needed.
-KeyArray = Union[PRNGKeyArray, Any]  # pytype: disable=invalid-annotation
+# This should be updated to PRNGKeyArray when it becomes a part of public JAX API
+KeyArray = Union[Any]
 
 
 class IMutualInformationPointEstimator(Protocol):

--- a/src/bmi/samplers/splitmultinormal.py
+++ b/src/bmi/samplers/splitmultinormal.py
@@ -1,6 +1,6 @@
 import numpy as np
-from jax import random  # pytype: disable=import-error
-from numpy.typing import ArrayLike  # pytype: disable=import-error
+from jax import random
+from numpy.typing import ArrayLike
 
 from bmi.interface import KeyArray
 from bmi.samplers.base import BaseSampler

--- a/tests/estimators/test_ksg.py
+++ b/tests/estimators/test_ksg.py
@@ -1,10 +1,10 @@
 import numpy as np
-import pytest  # pytype: disable=import-error
-from jax import random  # pytype: disable=import-error
-from sklearn.feature_selection import mutual_info_regression  # pytype: disable=import-error
+import pytest
+from jax import random
+from sklearn.feature_selection import mutual_info_regression
 
-import bmi.estimators.ksg as ksg  # pytype: disable=import-error
-from bmi.samplers.splitmultinormal import SplitMultinormal  # pytype: disable=import-error
+import bmi.estimators.ksg as ksg
+from bmi.samplers.splitmultinormal import SplitMultinormal
 
 
 def random_covariance(size: int, jitter: float = 1e-2, rng=0):

--- a/tests/samplers/test_splitmultinormal.py
+++ b/tests/samplers/test_splitmultinormal.py
@@ -1,8 +1,8 @@
 import numpy as np
-import pytest  # pytype: disable=import-error
-from jax import random  # pytype: disable=import-error
+import pytest
+from jax import random
 
-from bmi.samplers.splitmultinormal import SplitMultinormal  # pytype: disable=import-error
+from bmi.samplers.splitmultinormal import SplitMultinormal
 
 
 @pytest.mark.parametrize("y", (2, 5, 10))


### PR DESCRIPTION
@grfrederic thanks for explaining the issue with disabling `pytype`. I added a line making it use current environment and removed the (redundant) comments from the code.

Ready for review and the changes are minimal possible :slightly_smiling_face: 