### PR TITLE
Refactor KSG estimation

### DIFF
--- a/scripts/ksg_time_comparison.py
+++ b/scripts/ksg_time_comparison.py
@@ -1,0 +1,145 @@
+"""Simple comparison of the speed of our KSG estimators."""
+import argparse
+import time
+
+import numpy as np
+from jax import random
+
+import bmi.api as bmi
+
+
+class TimeIt:
+    """Context manager used to time a given procedure.
+
+    Example:
+        The code:
+        ```
+        import time
+        with TimeIt(message_start="Starting the sleep procedure...", message_end="It took {}."):
+            time.sleep(10)
+        ```
+        will produce to standard output
+        ```
+        Starting the sleep procedure...
+        It took 10 seconds.
+        ```
+    """
+
+    def __init__(self, message_start: str = "", message_end: str = "{}") -> None:
+        """
+
+        Args:
+            message_start: message to print at the beginning. Set to empty (default) for no message
+            message_end: format string to be printed at the end of the procedure.
+              Should contain "{}" which will be filled with the time.
+        """
+        if message_start:
+            print(message_start)
+        self.message_end = message_end
+        self.t0 = time.time()
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, traceback):
+        delta_t = time.time() - self.t0
+        message_fill = "{:.2f} seconds".format(delta_t)
+        print(self.message_end.format(message_fill))
+
+
+SLOW = "SLOW"
+NUMPY = "NUMPY"
+
+KSG_ESTIMATORS = {
+    SLOW: bmi.KSGEnsembleFirstEstimatorSlow,
+    NUMPY: bmi.KSGEnsembleFirstEstimator,
+}
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--ksg-type",
+        default="NUMPY",
+        choices=KSG_ESTIMATORS.keys(),
+        help="Which KSG estimator to use.",
+    )
+    parser.add_argument("--n-samples", default=1000, type=int, help="Number of samples.")
+    parser.add_argument("--dim-x", default=2, type=int, help="Dimension of the X variable.")
+    parser.add_argument(
+        "--dim-y",
+        default=None,
+        type=int,
+        help="Dimension of the Y variable. "
+        "By default it is equal to the dimension of the X variable.",
+    )
+    parser.add_argument("--neighborhood", default=5, type=int, help="Neighborhood size.")
+    parser.add_argument("--n-jobs", default=1, type=int, help="Number of launched jobs.")
+    parser.add_argument(
+        "--chunk-size", default=10, type=int, help="Chunk size for the NumPy-based KSG estimator."
+    )
+
+    return parser
+
+
+def get_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
+    args = parser.parse_args()
+
+    assert args.neighborhood >= 1
+    assert args.n_samples >= 1
+    assert args.chunk_size >= 1
+
+    assert args.dim_x >= 1
+    # By default, we set dim_y to dim_x
+    args.dim_y = args.dim_y or args.dim_x
+
+    return args
+
+
+def get_estimator(args: argparse.Namespace):
+    if args.ksg_type == SLOW:
+        return bmi.KSGEnsembleFirstEstimatorSlow(
+            neighborhoods=(args.neighborhood,),
+            n_jobs=args.n_jobs,
+        )
+    elif args.ksg_type == NUMPY:
+        return bmi.KSGEnsembleFirstEstimator(
+            neighborhoods=(args.neighborhood,),
+            n_jobs=args.n_jobs,
+            chunk_size=args.chunk_size,
+        )
+    else:
+        raise ValueError(f"KSG estimator type {args.ksg_type} not known.")
+
+
+def main() -> None:
+    parser = create_parser()
+    args = get_args(parser)
+
+    print("Settings:")
+    for k, v in vars(args).items():
+        print(f"\t{k}: {v}")
+
+    dim_total = args.dim_x + args.dim_y
+
+    with TimeIt(message_start="Creating samples...", message_end="\tTook {}."):
+        sampler = bmi.SplitMultinormal(
+            dim_x=args.dim_x,
+            dim_y=args.dim_y,
+            mean=np.zeros(dim_total),
+            covariance=np.eye(dim_total),
+        )
+        x, y = sampler.sample(n_points=args.n_samples, rng=random.PRNGKey(10))
+
+    estimator = get_estimator(args)
+
+    with TimeIt(message_start="Estimating MI...", message_end="\tTook {}."):
+        mi = estimator.estimate(x, y)
+
+    print(f"Calculated MI: {mi}")
+    print(f"True MI: {sampler.mutual_information()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bmi/api.py
+++ b/src/bmi/api.py
@@ -1,0 +1,8 @@
+from bmi.estimators.ksg import KSGEnsembleFirstEstimator, KSGEnsembleFirstEstimatorSlow
+from bmi.samplers.splitmultinormal import SplitMultinormal
+
+__all__ = [
+    "KSGEnsembleFirstEstimator",
+    "KSGEnsembleFirstEstimatorSlow",
+    "SplitMultinormal",
+]

--- a/src/bmi/estimators/ksg.py
+++ b/src/bmi/estimators/ksg.py
@@ -1,5 +1,5 @@
 """Kraskov estimators."""
-from typing import Sequence, cast
+from typing import Literal, Optional, Sequence, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -9,23 +9,47 @@ from sklearn import metrics, preprocessing
 from bmi.estimators.base import EstimatorNotFittedException
 from bmi.interface import IMutualInformationPointEstimator
 
+_AllowedContinuousMetric = Literal["euclidean", "manhattan", "chebyshev", "mahalonobis"]
+
 
 class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
     """Ensemble estimator built using the first approximation (equation (8) in the paper)."""
 
-    def __init__(self, neighborhoods: Sequence[int] = (5, 10), standardize: bool = True) -> None:
+    def __init__(
+        self,
+        neighborhoods: Sequence[int] = (5, 10),
+        standardize: bool = True,
+        metric_x: _AllowedContinuousMetric = "euclidean",
+        metric_y: Optional[_AllowedContinuousMetric] = None,
+        n_jobs: int = 1,
+    ) -> None:
         """
 
         Args:
             neighborhoods: sequence of positive integers,
               specifying the size of neighborhood for MI calculation
             standardize: whether to standardize the data before MI calculation, by default true
+            metric_x: metric on the X space
+            metric_y: metric on the Y space. If None, `metric_x` will be used
+            n_jobs: number of jobs to be launched to compute distances.
+              Use -1 to use all processors.
+
+        Note:
+            If you use Chebyshev (l-infinity) distance for both X and Y,
+            `KSGChebyshevEstimator` may be faster.
         """
         if min(neighborhoods) < 1:
             raise ValueError("Each neighborhood must be at least 1.")
 
         self._neighborhoods = list(neighborhoods)
         self._standardize = standardize
+
+        self._n_jobs: int = n_jobs
+
+        self._metric_x: _AllowedContinuousMetric = metric_x
+        self._metric_y: _AllowedContinuousMetric = (
+            metric_y or metric_x
+        )  # If `metric_y` is None, use `metric_x`
 
         self._fitted = False
         self._mi_dict = dict()  # set by fit()
@@ -50,8 +74,12 @@ class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
         n_points = np.shape(x)[0]
         for index in range(n_points):
             # Distances from x[index] to all the points:
-            distances_x = metrics.pairwise_distances(x[None, index], x)[0, :]
-            distances_y = metrics.pairwise_distances(y[None, index], y)[0, :]
+            distances_x = metrics.pairwise_distances(
+                x[None, index], x, metric=self._metric_x, n_jobs=self._n_jobs
+            )[0, :]
+            distances_y = metrics.pairwise_distances(
+                y[None, index], y, metric=self._metric_y, n_jobs=self._n_jobs
+            )[0, :]
 
             # In the product (XxY) space we use the maximum distance
             distances_z = np.maximum(distances_x, distances_y)
@@ -87,3 +115,11 @@ class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
         self.fit(x, y)
         predictions = np.asarray(list(self.get_predictions().values()))
         return cast(float, np.mean(predictions))
+
+
+class KSGEnsembleChebyshevEstimator(IMutualInformationPointEstimator):
+    """Mutual information estimator based on fast nearest neighbours,
+    available when Chebyshev (l-infty) metric is used for both X and Y spaces.
+    """
+
+    raise NotImplementedError

--- a/src/bmi/estimators/ksg.py
+++ b/src/bmi/estimators/ksg.py
@@ -201,7 +201,7 @@ class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
 
                 # Don't include the `i`th point itself in n_x and n_y
                 n_x = (distances_x < distances_k[:, None]).sum(axis=1) - 1  # Shape (batch_size,)
-                n_y = (distances_x < distances_k[:, None]).sum(axis=1) - 1  # Shape (batch_size,)
+                n_y = (distances_y < distances_k[:, None]).sum(axis=1) - 1  # Shape (batch_size,)
 
                 digammas = _DIGAMMA(n_x + 1) + _DIGAMMA(n_y + 1)  # Shape (batch_size,)
                 digammas_contribution = np.sum(digammas / n_points)

--- a/src/bmi/estimators/ksg.py
+++ b/src/bmi/estimators/ksg.py
@@ -204,10 +204,13 @@ class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
                 n_y = (distances_y < distances_k[:, None]).sum(axis=1) - 1  # Shape (batch_size,)
 
                 digammas = _DIGAMMA(n_x + 1) + _DIGAMMA(n_y + 1)  # Shape (batch_size,)
-                digammas_contribution = np.sum(digammas / n_points)
-                digammas_dict[k].append(digammas_contribution)
+                # We calculate mean(digammas) over all the points rather than the batch
+                digammas_mean_contribution = np.sum(digammas / n_points)
+                digammas_dict[k].append(digammas_mean_contribution)
 
         for k, digammas in digammas_dict.items():
+            # As the mean over all the points was calculated for each chunk separately,
+            # we should add the contributions from each chunk
             mi_estimate = _DIGAMMA(k) - np.sum(digammas) + _DIGAMMA(n_points)
             self._mi_dict[k] = max(0.0, mi_estimate)
 

--- a/src/bmi/estimators/ksg.py
+++ b/src/bmi/estimators/ksg.py
@@ -127,7 +127,7 @@ class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
         metric_x: _AllowedContinuousMetric = "euclidean",
         metric_y: Optional[_AllowedContinuousMetric] = None,
         n_jobs: int = 1,
-        chunk_size: int = 100,
+        chunk_size: int = 10,
     ) -> None:
         """
 
@@ -212,6 +212,102 @@ class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
             # As the mean over all the points was calculated for each chunk separately,
             # we should add the contributions from each chunk
             mi_estimate = _DIGAMMA(k) - np.sum(digammas) + _DIGAMMA(n_points)
+            self._mi_dict[k] = max(0.0, mi_estimate)
+
+        self._fitted = True
+
+    def get_predictions(self) -> dict[int, float]:
+        if not self._fitted:
+            raise EstimatorNotFittedException
+        return cast(dict[int, float], self._mi_dict.copy())
+
+    def estimate(self, x: ArrayLike, y: ArrayLike) -> float:
+        self.fit(x, y)
+        predictions = np.asarray(list(self.get_predictions().values()))
+        return cast(float, np.mean(predictions))
+
+
+class KSGEnsembleFirstEstimatorSlow(IMutualInformationPointEstimator):
+    """Ensemble estimator built using the first approximation (equation (8) in the paper).
+
+    Note:
+        `KSGEnsembleFirstEstimator` is a faster, NumPy-based, version of this one.
+        We decided to retain it for instructional purposes (as it's easier to read)
+    """
+
+    def __init__(
+        self,
+        neighborhoods: Sequence[int] = (5, 10),
+        standardize: bool = True,
+        metric_x: _AllowedContinuousMetric = "euclidean",
+        metric_y: Optional[_AllowedContinuousMetric] = None,
+        n_jobs: int = 1,
+    ) -> None:
+        """
+        Args:
+            neighborhoods: sequence of positive integers,
+              specifying the size of neighborhood for MI calculation
+            standardize: whether to standardize the data before MI calculation, by default true
+            metric_x: metric on the X space
+            metric_y: metric on the Y space. If None, `metric_x` will be used
+            n_jobs: number of jobs to be launched to compute distances.
+              Use -1 to use all processors.
+        """
+        self._neighborhoods = _cast_and_check_neighborhoods(neighborhoods)
+        self._standardize = standardize
+
+        self._n_jobs: int = n_jobs
+
+        self._metric_x: _AllowedContinuousMetric = metric_x
+        self._metric_y: _AllowedContinuousMetric = (
+            metric_y or metric_x
+        )  # If `metric_y` is None, use `metric_x`
+
+        self._fitted = False
+        self._mi_dict = dict()  # set by fit()
+
+    def fit(self, x: ArrayLike, y: ArrayLike) -> None:
+        space = _ProductSpace(x=x, y=y, standardize=self._standardize)
+
+        n_points = len(space)
+        if n_points <= max(self._neighborhoods):
+            raise ValueError(
+                f"Maximum neighborhood used is {max(self._neighborhoods)} "
+                f"but the number of points provided is only {n_points}."
+            )
+
+        digammas_dict = {k: [] for k in self._neighborhoods}
+
+        for index in range(n_points):
+            # Distances from x[index] to all the points:
+            distances_x = metrics.pairwise_distances(
+                space.x[None, index], space.x, metric=self._metric_x, n_jobs=self._n_jobs
+            )[0, :]
+            distances_y = metrics.pairwise_distances(
+                space.y[None, index], space.y, metric=self._metric_y, n_jobs=self._n_jobs
+            )[0, :]
+
+            # In the product (XxY) space we use the maximum distance
+            distances_z = np.maximum(distances_x, distances_y)
+            # And we sort the point indices by being the closest to the considered one
+            closest_points = sorted(range(len(distances_z)), key=lambda i: distances_z[i])
+
+            for k in self._neighborhoods:
+                # Note that the points are 0-indexed and that the "0th neighbor"
+                # is the point itself (as distance(x, x) = 0 is the smallest possible)
+                # Hence, the kth neighbour is at index k
+                kth_neighbour = closest_points[k]
+                distance = distances_z[kth_neighbour]
+
+                # Don't include the `i`th point itself in n_x and n_y
+                n_x = (distances_x < distance).sum() - 1
+                n_y = (distances_y < distance).sum() - 1
+
+                digammas_per_point = _DIGAMMA(n_x + 1) + _DIGAMMA(n_y + 1)
+                digammas_dict[k].append(digammas_per_point)
+
+        for k, digammas in digammas_dict.items():
+            mi_estimate = _DIGAMMA(k) - np.mean(digammas) + _DIGAMMA(n_points)
             self._mi_dict[k] = max(0.0, mi_estimate)
 
         self._fitted = True

--- a/src/bmi/estimators/ksg.py
+++ b/src/bmi/estimators/ksg.py
@@ -9,7 +9,7 @@ from sklearn import metrics, preprocessing
 from bmi.estimators.base import EstimatorNotFittedException
 from bmi.interface import IMutualInformationPointEstimator
 
-_AllowedContinuousMetric = Literal["euclidean", "manhattan", "chebyshev", "mahalonobis"]
+_AllowedContinuousMetric = Literal["euclidean", "manhattan", "chebyshev"]
 
 
 class KSGEnsembleFirstEstimator(IMutualInformationPointEstimator):
@@ -122,4 +122,4 @@ class KSGEnsembleChebyshevEstimator(IMutualInformationPointEstimator):
     available when Chebyshev (l-infty) metric is used for both X and Y spaces.
     """
 
-    raise NotImplementedError
+    ...

--- a/tests/estimators/test_ksg.py
+++ b/tests/estimators/test_ksg.py
@@ -1,3 +1,5 @@
+from typing import Optional, get_args
+
 import numpy as np
 import pytest
 from jax import random
@@ -89,8 +91,17 @@ def test_ksg_more_neighbors_than_points_raises(
         estimator.fit(x, x)
 
 
-@pytest.mark.parametrize("neighborhoods", [(2, 5), (1, 10)])
-def test_ksg_fit_predict(neighborhoods: tuple[int, ...], n_samples: int = 15) -> None:
+@pytest.mark.parametrize("n_jobs", [1, 2])
+@pytest.mark.parametrize("metric_x", get_args(ksg._AllowedContinuousMetric))
+@pytest.mark.parametrize("metric_y", [None, "euclidean"])
+@pytest.mark.parametrize("neighborhoods", [(2, 5), (1, 7)])
+def test_ksg_fit_predict(
+    neighborhoods: tuple[int, ...],
+    n_jobs: int,
+    metric_x: ksg._AllowedContinuousMetric,
+    metric_y: Optional[ksg._AllowedContinuousMetric],
+    n_samples: int = 10,
+) -> None:
     """Tests whether the estimator can be fitted
     and if it allows to get the predictions afterwards."""
 
@@ -104,7 +115,9 @@ def test_ksg_fit_predict(neighborhoods: tuple[int, ...], n_samples: int = 15) ->
     rng = random.PRNGKey(10)
     x_sample, y_sample = distribution.sample(n_samples, rng=rng)
 
-    estimator = ksg.KSGEnsembleFirstEstimator(neighborhoods=neighborhoods)
+    estimator = ksg.KSGEnsembleFirstEstimator(
+        neighborhoods=neighborhoods, metric_x=metric_x, metric_y=metric_y, n_jobs=n_jobs
+    )
     estimator.fit(x_sample, y_sample)
 
     predictions = estimator.get_predictions()


### PR DESCRIPTION
This PR:
  - Slightly refactors the KSG estimator (better abstractions).
  - Adds a NumPy-based KSG estimator. Rather than using Python `for` loop for individual points, we process the data in batches. This allows us to trade some memory for speed (as we now process batches partially with NumPy and partially with several threads).

The new estimator seems to be ~5 times faster:
```
$ python scripts/ksg_time_comparison.py --n-samples 4000  --ksg-type SLOW
Settings:
	ksg_type: SLOW
	n_samples: 4000
	dim_x: 2
	dim_y: 2
	neighborhood: 5
	n_jobs: 1
	chunk_size: 10
Creating samples...
	Took 0.21 seconds.
Estimating MI...
	Took 5.08 seconds.
Calculated MI: 0.002
True MI: 0.0
$ python scripts/ksg_time_comparison.py --n-samples 4000  --ksg-type NUMPY
Settings:
	ksg_type: NUMPY
	n_samples: 4000
	dim_x: 2
	dim_y: 2
	neighborhood: 5
	n_jobs: 1
	chunk_size: 10
Creating samples...
	Took 0.22 seconds.
Estimating MI...
	Took 1.00 seconds.
Calculated MI: 0.002
True MI: 0.0
```

Also, surprisingly, allowing for more processes seemed to hurt the performance on my machine. Perhaps moving the arrays around is not forth for 10,000 (and less) data points.

Update: it seems that using NumPy to sort gives ~3 times speed up. Using chunks of size 10 on this data set size adds another ~1.5 speed up (we exchange some iterations of slow Python's `for` loop for NumPy's one in C).