### PR TITLE
Histogram-based MI estimation

### DIFF
--- a/src/bmi/estimators/histogram.py
+++ b/src/bmi/estimators/histogram.py
@@ -1,0 +1,65 @@
+"""Histogram-based approach.
+
+Note: if a bin p(x, y) has zero counts, we assign zero contribution from it to the MI:
+  MI \\approx \\sum p(x, y) \\log( p(x, y) / p(x)p(y) )
+"""
+from itertools import product
+from typing import Optional
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from bmi.interface import IMutualInformationPointEstimator
+from bmi.utils import ProductSpace
+
+
+class HistogramEstimator(IMutualInformationPointEstimator):
+    def __init__(
+        self, n_bins_x: int = 5, n_bins_y: Optional[int] = None, standardize: bool = True
+    ) -> None:
+        """
+        Args:
+            n_bins_x: number of bins per each X dimension
+            n_bins_y: number of bins per each Y dimension. Leave to None to use `n_bins_x`
+            standardize: whether to standardize the data set
+        """
+        self._n_bins_x = n_bins_x
+        self._n_bins_y = n_bins_y or n_bins_x
+        self._standardize = standardize
+
+    def estimate(self, x: ArrayLike, y: ArrayLike) -> float:
+        """MI estimate."""
+        space = ProductSpace(x=x, y=y, standardize=self._standardize)
+        bins = [self._n_bins_x for _ in range(space.dim_x)] + [
+            self._n_bins_y for _ in range(space.dim_y)
+        ]
+
+        histogram, _ = np.histogramdd(space.xy, bins=bins, density=False)
+        range_x = self._n_bins_x**space.dim_x
+        range_y = self._n_bins_y**space.dim_y
+
+        flat_histogram = np.zeros((range_x, range_y), dtype=float)
+        for i, x in enumerate(product(range(self._n_bins_x), repeat=space.dim_x)):
+            for j, y in enumerate(product(range(self._n_bins_y), repeat=space.dim_y)):
+                index = tuple(x) + tuple(y)
+                flat_histogram[i, j] = histogram[tuple(index)]
+
+        del i, j, space, histogram
+
+        # Convert from counts to (empirical) densities
+        p_xy = flat_histogram / np.sum(flat_histogram)
+        # Calculate marginals by integrating out the other variable
+        p_x = p_xy.sum(axis=1)
+        p_y = p_xy.sum(axis=0)
+
+        assert p_x.shape == (range_x,)
+        assert p_y.shape == (range_y,)
+
+        # Calculate MI
+        mi = 0.0
+        for i in range(range_x):
+            for j in range(range_y):
+                if p_xy[i, j] > 0:
+                    mi += p_xy[i, j] * (np.log(p_xy[i, j]) - np.log(p_x[i]) - np.log(p_y[j]))
+
+        return mi

--- a/src/bmi/utils.py
+++ b/src/bmi/utils.py
@@ -55,6 +55,14 @@ class ProductSpace:
         return self.x.shape[0]
 
     @property
+    def dim_x(self) -> int:
+        return self._x.shape[1]
+
+    @property
+    def dim_y(self) -> int:
+        return self._y.shape[1]
+
+    @property
     def x(self) -> np.ndarray:
         return self._x
 

--- a/tests/estimators/test_histogram.py
+++ b/tests/estimators/test_histogram.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 import pytest
 from jax import random
@@ -8,8 +10,11 @@ from bmi.samplers.splitmultinormal import SplitMultinormal
 
 @pytest.mark.parametrize("n_points", [2000])
 @pytest.mark.parametrize("correlation", [0.0, 0.5, 0.8])
-@pytest.mark.parametrize("n_bins", [8, 10, 12, 20])
-def test_estimate_mi_histogram_2d(n_points: int, correlation: float, n_bins: int) -> None:
+@pytest.mark.parametrize("n_bins_x", [10, 12, 20])
+@pytest.mark.parametrize("n_bins_y", [None, 10])
+def test_estimate_mi_histogram_2d(
+    n_points: int, correlation: float, n_bins_x: int, n_bins_y: Optional[int]
+) -> None:
     """Histogram-based approach for a 2D Gaussian with known correlation."""
     covariance = np.array(
         [
@@ -26,7 +31,7 @@ def test_estimate_mi_histogram_2d(n_points: int, correlation: float, n_bins: int
     rng = random.PRNGKey(19)
     points_x, points_y = distribution.sample(n_points, rng=rng)
 
-    estimator = HistogramEstimator(n_bins_x=n_bins)
+    estimator = HistogramEstimator(n_bins_x=n_bins_x, n_bins_y=n_bins_y)
     estimated_mi = estimator.estimate(points_x, points_y)
 
     true_mi = distribution.mutual_information()

--- a/tests/estimators/test_histogram.py
+++ b/tests/estimators/test_histogram.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+from jax import random
+
+from bmi.estimators.histogram import HistogramEstimator
+from bmi.samplers.splitmultinormal import SplitMultinormal
+
+
+@pytest.mark.parametrize("n_points", [2000])
+@pytest.mark.parametrize("correlation", [0.0, 0.5, 0.8])
+@pytest.mark.parametrize("n_bins", [6, 8, 10])
+def test_estimate_mi_ksg_2d(n_points: int, correlation: float, n_bins: int) -> None:
+    """Simple tests for the KSG estimator with 2D Gaussian with known correlation."""
+    covariance = np.array(
+        [
+            [1.0, correlation],
+            [correlation, 1.0],
+        ]
+    )
+    distribution = SplitMultinormal(
+        dim_x=1,
+        dim_y=1,
+        mean=np.zeros(2),
+        covariance=covariance,
+    )
+    rng = random.PRNGKey(19)
+    points_x, points_y = distribution.sample(n_points, rng=rng)
+
+    estimator = HistogramEstimator(n_bins_x=n_bins)
+    estimated_mi = estimator.estimate(points_x, points_y)
+
+    true_mi = distribution.mutual_information()
+
+    assert estimated_mi == pytest.approx(true_mi, rel=0.15, abs=0.12)

--- a/tests/estimators/test_histogram.py
+++ b/tests/estimators/test_histogram.py
@@ -8,9 +8,9 @@ from bmi.samplers.splitmultinormal import SplitMultinormal
 
 @pytest.mark.parametrize("n_points", [2000])
 @pytest.mark.parametrize("correlation", [0.0, 0.5, 0.8])
-@pytest.mark.parametrize("n_bins", [6, 8, 10])
-def test_estimate_mi_ksg_2d(n_points: int, correlation: float, n_bins: int) -> None:
-    """Simple tests for the KSG estimator with 2D Gaussian with known correlation."""
+@pytest.mark.parametrize("n_bins", [8, 10, 12, 20])
+def test_estimate_mi_histogram_2d(n_points: int, correlation: float, n_bins: int) -> None:
+    """Histogram-based approach for a 2D Gaussian with known correlation."""
     covariance = np.array(
         [
             [1.0, correlation],
@@ -31,4 +31,4 @@ def test_estimate_mi_ksg_2d(n_points: int, correlation: float, n_bins: int) -> N
 
     true_mi = distribution.mutual_information()
 
-    assert estimated_mi == pytest.approx(true_mi, rel=0.15, abs=0.12)
+    assert estimated_mi == pytest.approx(true_mi, rel=0.12, abs=0.08)


### PR DESCRIPTION
This PR adds the simplest approach to the MI estimation. We estimate _discrete_ $p(x, y)$ by binning and use the formula 
$$I(X; Y) \approx \sum_{(x, y) \in \mathcal X \times \mathcal Y } p(x, y) \log \frac{p(x, y)}{p(x)p(y)}.$$

As we bin each dimension of $\mathcal X$ into $n_X$ bins and each dimension of $\mathcal Y$ into $n_Y$ bins, we need to have
$$n_X^{\dim \mathcal X} \cdot n_Y^{\dim \mathcal Y} \ge 2^{\dim \mathcal X + \dim \mathcal Y}$$
bins – this quickly becomes too large both in terms of time and memory requirements.

Note that the current implementation uses `np.histogramdd` and NumPy arrays won't be able to handle the case $\dim \mathcal X + \dim \mathcal Y > 32$. (Anyway, even for 2 bins per dimension this would require dozens of gigabytes of RAM).