### PR TITLE
Add MINE

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,19 +1,78 @@
+import dataclasses
+
 import pytest
 
 
+@dataclasses.dataclass
+class TurnOnTestSuiteArgument:
+    """CLI argument together with a keyword used to mark tests turned off by default.
+
+    Attrs:
+        cli_flag: CLI flag to be used to turn on an optional test suite, e.g., --run-r
+        help_message: CLI help message, describing the flag
+        mark_keyword: keyword used to mark the unit tests to be skipped
+            if the flag is not specified.
+            Note that it should be a valid Python name, e.g., requires_r
+        inivalue_line_description: a short description of the marker `mark_keyword`.
+            See also: `inivalue_line`
+    """
+
+    cli_flag: str
+    help_message: str
+    mark_keyword: str
+    inivalue_line_description: str
+
+    def reason(self) -> str:
+        """Reason for skipping, generated when the tests are run."""
+        return f"Need {self.cli_flag} option to run."
+
+    def inivalue_line(self) -> str:
+        return f"{self.mark_keyword}: {self.inivalue_line_description}"
+
+
+TURN_ON_ARGUMENTS = [
+    TurnOnTestSuiteArgument(
+        cli_flag="--run-r",
+        help_message="Run tests requiring R dependencies.",
+        mark_keyword="requires_r",
+        inivalue_line_description="mark test as requiring R dependencies to run.",
+    ),
+    TurnOnTestSuiteArgument(
+        cli_flag="--run-mine-pytorch",
+        help_message="Run MINE tests based on non-default dependencies (PyTorch, in particular).",
+        mark_keyword="requires_mine_pytorch",
+        inivalue_line_description="mark test as requiring PyTorch MINE implementation.",
+    ),
+]
+
+
 def pytest_addoption(parser):
-    parser.addoption("--run-r", action="store_true", default=False, help="Run tests requiring R.")
+    for argument in TURN_ON_ARGUMENTS:
+        parser.addoption(
+            argument.cli_flag,
+            action="store_true",
+            default=False,
+            help=argument.help_message,
+        )
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "requires_r: mark test as requiring R dependencies to run.")
+    for argument in TURN_ON_ARGUMENTS:
+        config.addinivalue_line("markers", argument.inivalue_line())
+
+
+def add_skipping_markers(
+    argument: TurnOnTestSuiteArgument,
+    config,
+    items,
+) -> None:
+    if not config.getoption(argument.cli_flag):
+        skip = pytest.mark.skip(reason=argument.reason())
+        for item in items:
+            if argument.mark_keyword in item.keywords:
+                item.add_marker(skip)
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--run-r"):
-        # --run-r given in cli: do not skip tests requiring R
-        return
-    skip_r = pytest.mark.skip(reason="Need --run-r option to run")
-    for item in items:
-        if "requires_r" in item.keywords:
-            item.add_marker(skip_r)
+    for argument in TURN_ON_ARGUMENTS:
+        add_skipping_markers(argument=argument, config=config, items=items)

--- a/external/README.md
+++ b/external/README.md
@@ -10,10 +10,35 @@ For example, they may use auxiliary dependencies or even be implemented in other
 ### Julia and TransferEntropy.jl
 In the file `mi_estimator.jl` we have a Julia wrapper around [TransferEntropy.jl](https://juliadynamics.github.io/TransferEntropy.jl/).
 
-Note that you need to [install Julia](https://julialang.org/downloads/) first and install the needed dependencies (instructions provided in the file).
+Note that you need to [install Julia](https://julialang.org/downloads/) first and then install the needed dependencies:
+```
+$ julia
+julia> using Pkg
+julia> Pkg.add(["ArgParse", "CSV", "DataFrames", "TransferEntropy"])
+```
 
 ### R and the rmi package
 
 In the file `rmi.R` we have an R wrapper around the [rmi package](https://cran.r-project.org/web/packages/rmi/index.html).
 
-Note that you need to install R first and install the necessary dependencies (instructions provided in the file).
+Note that you need to install R first and then install the necessary dependencies:
+```
+$ R
+> install.packages("argparse", "dplyr", "rmi")
+```
+
+### MINE
+As a dependency we use a [custom fork](https://github.com/pawel-czyz/mine-mist) of the [Latte project](https://github.com/boevalab/latte),
+which contains MINE and MIST implementations (developed by Anej Svete).
+The MINE implementation has been based on the original [Python + PyTorch implementation of MINE](https://github.com/gtegner/mine-pytorch).
+
+The fork can be installed together with the package as an optional dependency:
+```
+$ pip install ".[mine]"
+```
+
+Alternatively, one can install it manually:
+```
+$ pip install git+https://github.com/pawel-czyz/mine-mist.git
+```
+

--- a/external/README.md
+++ b/external/README.md
@@ -27,6 +27,12 @@ $ R
 > install.packages("argparse", "dplyr", "rmi")
 ```
 
+You can check if the dependencies have been installed properly by running
+```
+$ pytest tests/benchmark/test_wrapper --run-r
+```
+Note that without `--run-r` flag the tests will be skipped.
+
 ### MINE
 As a dependency we use a [custom fork](https://github.com/pawel-czyz/mine-mist) of the [Latte project](https://github.com/boevalab/latte),
 which contains MINE and MIST implementations (developed by Anej Svete).
@@ -42,3 +48,8 @@ Alternatively, one can install it manually:
 $ pip install git+https://github.com/pawel-czyz/mine-mist.git
 ```
 
+You can run unit tests associated to it via:
+```
+$ pytest tests/estimators/external/test_mine.py --run-mine-pytorch
+```
+Note that without `--run-mine-pytorch` the tests will be skipped.

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,19 @@
+# External estimators
+
+In this directory we add wrappers around estimators
+which are not part of the official Python package.
+
+For example, they may use auxiliary dependencies or even be implemented in other languages.
+
+## Available wrappers and estimators
+
+### Julia and TransferEntropy.jl
+In the file `mi_estimator.jl` we have a Julia wrapper around [TransferEntropy.jl](https://juliadynamics.github.io/TransferEntropy.jl/).
+
+Note that you need to [install Julia](https://julialang.org/downloads/) first and install the needed dependencies (instructions provided in the file).
+
+### R and the rmi package
+
+In the file `rmi.R` we have an R wrapper around the [rmi package](https://cran.r-project.org/web/packages/rmi/index.html).
+
+Note that you need to install R first and install the necessary dependencies (instructions provided in the file).

--- a/external/mi_estimator.jl
+++ b/external/mi_estimator.jl
@@ -1,8 +1,15 @@
+# ===================================================================================
 # A mutual information estimator using TransferEntropy.jl
 # library in Julia
 # Use as:
-# julia external/mi_estimator.jl path_to_file_with_samples.csv seed dim_x dim_y
+# $ julia external/mi_estimator.jl path_to_file_with_samples.csv seed dim_x dim_y
 # Note that the CSV must be formatted as seed, X1, ..., Xn, Y1, ..., Yn
+#
+# To install the dependencies run:
+# $ julia
+# > using Pkg
+# > Pkg.add(["ArgParse", "CSV", "DataFrames", "TransferEntropy"])
+# ===================================================================================
 using ArgParse
 using CSV
 using DataFrames

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ test =
     pytest
     pytest-cov
     pytest-xdist
+mine =
+    latte @ git+https://github.com/pawel-czyz/mine-mist.git
 
 [pytype]
 inputs =

--- a/src/bmi/estimators/external/__init__.py
+++ b/src/bmi/estimators/external/__init__.py
@@ -1,0 +1,4 @@
+"""External estimators, which need additional Python dependencies.
+
+In particular, this subpackage should never be imported in the core code.
+"""

--- a/src/bmi/estimators/external/mine.py
+++ b/src/bmi/estimators/external/mine.py
@@ -10,11 +10,14 @@ from typing import Literal, Sequence
 from numpy.typing import ArrayLike
 
 try:
+    # pytype: disable=import-error
     import torch
     import torch.nn as nn
     from latte.models.mine import mine
     from latte.modules.data import datamodules as dm
     from pytorch_lightning import Trainer
+
+    # pytype: enable=import-error
 except ImportError as e:
     raise ImportError(
         f"It seems that you are missing a dependency."

--- a/src/bmi/estimators/external/mine.py
+++ b/src/bmi/estimators/external/mine.py
@@ -1,0 +1,240 @@
+"""The MINE estimator.
+
+Note:
+    This module uses optional dependencies,
+    so it should NEVER be imported by any of the core modules and APIs.
+"""
+import enum
+from typing import Literal, Sequence
+
+from numpy.typing import ArrayLike
+
+try:
+    import torch
+    import torch.nn as nn
+    from latte.models.mine import mine
+    from latte.modules.data import datamodules as dm
+    from pytorch_lightning import Trainer
+except ImportError as e:
+    raise ImportError(
+        f"It seems that you are missing a dependency."
+        f'Try calling `pip install ".[mine]"`. Raised error {e}.'
+    )
+
+from bmi.estimators.base import EstimatorNotFittedException
+from bmi.interface import IMutualInformationPointEstimator
+from bmi.utils import ProductSpace
+
+
+def _parse_layers(dimensions: Sequence[int]) -> list[tuple[int, int]]:
+    if len(dimensions) < 2:
+        raise ValueError("At least two dimensions must be specified (input and output).")
+
+    layers = []
+    for i in range(len(dimensions) - 1):
+        input_dim = dimensions[i]
+        output_dim = dimensions[i + 1]
+        layers.append((input_dim, output_dim))
+    return layers
+
+
+def _construct_statistics_network(
+    dim_x: int,
+    dim_y: int,
+    hidden_layers: Sequence[int] = (5,),
+    bias: bool = True,
+    activation: nn.Module = nn.ReLU(),
+) -> mine.StatisticsNetwork:
+    """Constructs the statistics network.
+
+    Args:
+        dim_x: dimension of the X variable
+        dim_y: dimensions of the Y variable
+        hidden_layers: dimensions of the hidden linear layers of the statistics neural network
+        bias: whether to use bias in the linear layers
+        activation: non-linear activation function to be used
+    """
+    layers_spec = _parse_layers([dim_x + dim_y] + list(hidden_layers))
+    layers = []
+    for input_dim, output_dim in layers_spec:
+        layers.append(nn.Linear(input_dim, output_dim, bias=bias))
+        layers.append(activation)
+
+    return mine.StatisticsNetwork(
+        S=nn.Sequential(*layers),
+        out_dim=hidden_layers[-1],
+    )
+
+
+def _unpack_result(wrapped) -> float:
+    """The numerical MI estimate we retrieve is `wrapped` as:
+        [{'some_name': 0.002}]
+    the point is now to find this 0.002.
+    """
+    vals = list(wrapped[0].values())
+    if len(vals) != 1:
+        raise ValueError(f"Item {wrapped} is not formatted appropriately.")
+    return vals[0]
+
+
+class MINEObjectiveType(enum.Enum):
+    MINE = "mine"
+    F_DIV = "f-div"
+    MINE_BIASED = "mine-biased"
+
+
+def _parse_objective_type(objective: MINEObjectiveType) -> mine.MINEObjectiveType:
+    if objective == objective.MINE:
+        return mine.MINEObjectiveType.MINE
+    elif objective.MINE_BIASED:
+        return mine.MINEObjectiveType.MINE_BIASED
+    elif objective == objective.F_DIV:
+        return mine.MINEObjectiveType.F_DIV
+    else:
+        raise ValueError("Objective type not recognized.")
+
+
+class MutualInformationNeuralEstimator(IMutualInformationPointEstimator):
+    def __init__(
+        self,
+        # Data parameters
+        standardize: bool = True,
+        proportion_train: float = 1 / 3,
+        proportion_valid: float = 1 / 3,
+        # MINE parameters
+        objective: MINEObjectiveType = MINEObjectiveType.MINE,
+        alpha: float = 1e-2,
+        # Statistics NN parameters
+        hidden_layers: Sequence[int] = (10, 5),
+        bias: bool = True,
+        # Training parameters
+        learning_rate: float = 1e-3,
+        max_epochs: int = 300,
+        batch_size: int = 32,
+        device: Literal["cpu", "gpu"] = "cpu",
+        seed: int = 714,
+    ) -> None:
+        """
+
+        Args:
+            standardize: whether to standardize the data (recommended)
+            proportion_train: specifies the fraction of samples to go into the training data set
+            proportion_valid: specifies the fraction of samples to go into the validation data set
+            hidden_layers: specifices the layers of the statistics NN
+            bias: specifies the bias in the statistics NN
+            seed: random seed for PyTorch
+        """
+        # Whether the model has been fitted to the data
+        # and can be queried about the training
+        self._fitted: bool = False
+        self._trainer = None
+        self._data_module = None
+        self._results = None
+
+        # Data processing parameters
+        self._standardize = standardize
+        self._proportion_train = proportion_train
+        self._proportion_valid = proportion_valid
+        self._proportion_test = 1 - (proportion_train + proportion_valid)
+
+        if min(self._proportion_train, self._proportion_valid, self._proportion_test) < 0:
+            raise ValueError("The proportion of each data set must be positive.")
+
+        # MINE parameters
+        self._alpha = alpha
+        self._objective = objective
+
+        # Statistics network parameters
+        self._hidden_layers = hidden_layers
+        self._bias = bias
+
+        # Training parameters
+        if max_epochs < 1:
+            raise ValueError("Maximum number of methods must be at least 1.")
+        self._max_epochs = max_epochs
+        self._device = device
+        self._learning_rate = learning_rate
+        if learning_rate < 0:
+            raise ValueError("Learning rate must be positive.")
+        self._batch_size = batch_size
+        if batch_size < 1:
+            raise ValueError("Batch size must be at least 1.")
+        self._seed = seed
+
+    def fit(self, x: ArrayLike, y: ArrayLike) -> None:
+        space = ProductSpace(x=x, y=y, standardize=self._standardize)
+
+        torch.manual_seed(self._seed)
+
+        data_module = dm.GenericDataModule(
+            X=torch.from_numpy(space.x).float(),
+            Y=torch.from_numpy(space.y).float(),
+            p_train=self._proportion_train,
+            p_val=self._proportion_valid,
+            batch_size=self._batch_size,
+        )
+
+        network = _construct_statistics_network(
+            dim_x=space.dim_x,
+            dim_y=space.dim_y,
+            hidden_layers=self._hidden_layers,
+            bias=self._bias,
+        )
+        model = mine.StandaloneMINE(
+            T=network,
+            kind=_parse_objective_type(self._objective),
+            alpha=self._alpha,
+        )
+        trainer = Trainer(
+            max_epochs=self._max_epochs,
+            enable_model_summary=False,
+            enable_progress_bar=False,
+            accelerator=self._device,
+        )
+        trainer.fit(model, datamodule=data_module)
+
+        results = {
+            "test": _unpack_result(
+                trainer.test(ckpt_path="best", dataloaders=data_module, verbose=False)
+            ),
+            "valid": _unpack_result(
+                trainer.validate(ckpt_path="best", dataloaders=data_module, verbose=False)
+            ),
+            "train": _unpack_result(
+                trainer.validate(
+                    ckpt_path="best", dataloaders=data_module.train_dataloader(), verbose=False
+                )
+            ),
+        }
+
+        self._trainer = trainer
+        self._data_module = data_module
+        self._results = results
+        self._fitted = True
+
+    def get_trainer(self) -> Trainer:
+        if not self._fitted or self._trainer is None:
+            raise EstimatorNotFittedException
+        return self._trainer
+
+    def get_data_module(self):
+        return self._data_module
+
+    def mi_train(self) -> float:
+        if not self._fitted or self._results is None:
+            raise EstimatorNotFittedException
+        return self._results["train"]
+
+    def mi_valid(self) -> float:
+        if not self._fitted or self._results is None:
+            raise EstimatorNotFittedException
+        return self._results["valid"]
+
+    def mi_test(self) -> float:
+        if not self._fitted or self._results is None:
+            raise EstimatorNotFittedException
+        return self._results["test"]
+
+    def estimate(self, x: ArrayLike, y: ArrayLike) -> float:
+        self.fit(x, y)
+        return self.mi_test()

--- a/tests/estimators/external/test_mine.py
+++ b/tests/estimators/external/test_mine.py
@@ -6,7 +6,7 @@ from bmi.samplers.api import SplitMultinormal
 
 
 def get_estimator() -> IMutualInformationPointEstimator:
-    import torch
+    import torch  # pytype: disable=import-error
 
     import bmi.estimators.external.mine as mine
 
@@ -14,12 +14,12 @@ def get_estimator() -> IMutualInformationPointEstimator:
     return mine.MutualInformationNeuralEstimator(
         max_epochs=100,
         device=device,
-        hidden_layers=(8, 3),
+        hidden_layers=(15, 10),
     )
 
 
 @pytest.mark.requires_mine_pytorch
-def test_estimate_mi_2d(n_points: int = 10_000, correlation: float = 0.8) -> None:
+def test_estimate_mi_2d(n_points: int = 15_000, correlation: float = 0.8) -> None:
     covariance = np.array(
         [
             [1.0, correlation],
@@ -38,4 +38,4 @@ def test_estimate_mi_2d(n_points: int = 10_000, correlation: float = 0.8) -> Non
     true_mi = distribution.mutual_information()
     estimate = estimator.estimate(points_x, points_y)
 
-    assert estimate == pytest.approx(true_mi, abs=0.2)
+    assert estimate == pytest.approx(true_mi, abs=0.03, rel=0.02)

--- a/tests/estimators/external/test_mine.py
+++ b/tests/estimators/external/test_mine.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from bmi.interface import IMutualInformationPointEstimator
+from bmi.samplers.api import SplitMultinormal
+
+
+def get_estimator() -> IMutualInformationPointEstimator:
+    import torch
+
+    import bmi.estimators.external.mine as mine
+
+    device = "gpu" if torch.cuda.is_available() else "cpu"
+    return mine.MutualInformationNeuralEstimator(
+        max_epochs=100,
+        device=device,
+        hidden_layers=(8, 3),
+    )
+
+
+@pytest.mark.requires_mine_pytorch
+def test_estimate_mi_2d(n_points: int = 10_000, correlation: float = 0.8) -> None:
+    covariance = np.array(
+        [
+            [1.0, correlation],
+            [correlation, 1.0],
+        ]
+    )
+    distribution = SplitMultinormal(
+        dim_x=1,
+        dim_y=1,
+        mean=np.zeros(2),
+        covariance=covariance,
+    )
+    points_x, points_y = distribution.sample(n_points, rng=19)
+
+    estimator = get_estimator()
+    true_mi = distribution.mutual_information()
+    estimate = estimator.estimate(points_x, points_y)
+
+    assert estimate == pytest.approx(true_mi, abs=0.2)


### PR DESCRIPTION
This PR adds a wrapper around the MINE estimator implemented in PyTorch.

- [x] Add an estimator matching the interface wrapping around MINE.
- [x] Add optional tests, which can be enabled by a CLI flag (similarly to `--run-r` for tests of the wrappers around R estimators).
- [x] Improve documentation about external estimators, so it's documented how to install them.


While it's not JAX-based, I hope it suffices to resolve https://github.com/pawel-czyz/bmi/issues/8.

----
_Background story_
In the end it was trickier than my "it's super-easy, I'll do this in 10 minutes" estimate and took two days. [Hofstadter's law](https://en.wikipedia.org/wiki/Hofstadter%27s_law) attacked again :smiling_face_with_tear: 

After some experimentation with git submodules and different implementations on the market, I decided to fork [Latte](https://github.com/boevalab/latte) and prune some dependencies (and hence utilities) to a reasonable amount. The fork is available [here](https://github.com/pawel-czyz/mine-mist).