### PR TITLE
Refactoring the code: more parameters

### DIFF
--- a/src/bmi/benchmark/wrapper.py
+++ b/src/bmi/benchmark/wrapper.py
@@ -59,6 +59,7 @@ def run_external_estimator(
     """
     task_directory = TaskDirectory(task_path)
     metadata = TaskMetadata(**task_directory.load_metadata())
+    estimator_params: dict = {} if estimator_params is None else estimator_params
 
     our_args = [
         str(task_directory.samples),
@@ -77,6 +78,7 @@ def run_external_estimator(
         mi_estimate=mi_estimate,
         time_in_seconds=timer.check(),
         estimator_params=estimator_params,
+        task_params=metadata.task_params,
     )
 
 
@@ -84,8 +86,8 @@ class ExternalEstimator(abc.ABC):
     def __init__(self, estimator_id: Optional[str]) -> None:
         self._estimator_id = estimator_id
 
-    def _estimator_params(self) -> Optional[dict]:
-        return None
+    def _estimator_params(self) -> dict:
+        return {}
 
     @abc.abstractmethod
     def _precommands(self) -> list[str]:

--- a/src/bmi/estimators/external/mine.py
+++ b/src/bmi/estimators/external/mine.py
@@ -130,7 +130,7 @@ class AllMINEParams(pydantic.BaseModel):
     mine: MINESpecificParams = pydantic.Field(default_factory=MINESpecificParams)
     statistics_nn: StatisticsNNParams = pydantic.Field(default_factory=StatisticsNNParams)
     training: TrainingParams = pydantic.Field(default_factory=TrainingParams)
-    seed: int = pydantic.Field(default_factory=714)
+    seed: int = pydantic.Field(default=714)
 
 
 class MutualInformationNeuralEstimator(IMutualInformationPointEstimator):

--- a/src/bmi/estimators/function_wrapper.py
+++ b/src/bmi/estimators/function_wrapper.py
@@ -1,24 +1,40 @@
-from typing import Callable
+from typing import Callable, Optional
 
 import numpy as np
 from numpy.typing import ArrayLike
+from pydantic import BaseModel
 
 from bmi.interface import IMutualInformationPointEstimator
+
+
+class _EmptyParams(BaseModel):
+    pass
 
 
 class FunctionalEstimator(IMutualInformationPointEstimator):
     """Wraps a function estimating mutual information to the estimator interface."""
 
-    def __init__(self, /, func: Callable[[np.ndarray, np.ndarray], float]) -> None:
+    def __init__(
+        self,
+        /,
+        func: Callable[[np.ndarray, np.ndarray], float],
+        *,
+        params: Optional[BaseModel] = None,
+    ) -> None:
         """
         Args:
             func: takes X (shape (n_samples, dim_x) and Y samples (shape (n_samples, dim_y))
               and returns the mutual information estimate (float)
+            params: parameters of the estimator
         """
         self._estimator_function = func
+        self._params = params if params is not None else _EmptyParams()
 
     def estimate(self, x: ArrayLike, y: ArrayLike) -> float:
         x = np.asarray(x)
         y = np.asarray(y)
 
         return self._estimator_function(x, y)
+
+    def parameters(self) -> BaseModel:
+        return self._params

--- a/src/bmi/estimators/histogram.py
+++ b/src/bmi/estimators/histogram.py
@@ -7,10 +7,17 @@ from itertools import product
 from typing import Optional
 
 import numpy as np
+import pydantic
 from numpy.typing import ArrayLike
 
 from bmi.interface import IMutualInformationPointEstimator
 from bmi.utils import ProductSpace
+
+
+class HistogramEstimatorParams(pydantic.BaseModel):
+    n_bins_x: pydantic.PositiveInt
+    n_bins_y: pydantic.PositiveInt
+    standardize: bool
 
 
 class HistogramEstimator(IMutualInformationPointEstimator):
@@ -23,24 +30,30 @@ class HistogramEstimator(IMutualInformationPointEstimator):
             n_bins_y: number of bins per each Y dimension. Leave to None to use `n_bins_x`
             standardize: whether to standardize the data set
         """
-        self._n_bins_x = n_bins_x
-        self._n_bins_y = n_bins_y or n_bins_x
-        self._standardize = standardize
+        self._params = HistogramEstimatorParams(
+            n_bins_x=n_bins_x,
+            n_bins_y=n_bins_y or n_bins_x,  # If `n_bins_y` is None, use `n_bins_x`.
+            standardize=standardize,
+        )
+
+    def parameters(self) -> HistogramEstimatorParams:
+        return self._params
 
     def estimate(self, x: ArrayLike, y: ArrayLike) -> float:
         """MI estimate."""
-        space = ProductSpace(x=x, y=y, standardize=self._standardize)
-        bins = [self._n_bins_x for _ in range(space.dim_x)] + [
-            self._n_bins_y for _ in range(space.dim_y)
-        ]
+        n_bins_x = self._params.n_bins_x
+        n_bins_y = self._params.n_bins_y
+
+        space = ProductSpace(x=x, y=y, standardize=self._params.standardize)
+        bins = [n_bins_x for _ in range(space.dim_x)] + [n_bins_y for _ in range(space.dim_y)]
 
         histogram, _ = np.histogramdd(space.xy, bins=bins, density=False)
-        range_x = self._n_bins_x**space.dim_x
-        range_y = self._n_bins_y**space.dim_y
+        range_x = n_bins_x**space.dim_x
+        range_y = n_bins_y**space.dim_y
 
         flat_histogram = np.zeros((range_x, range_y), dtype=float)
-        for i, x in enumerate(product(range(self._n_bins_x), repeat=space.dim_x)):
-            for j, y in enumerate(product(range(self._n_bins_y), repeat=space.dim_y)):
+        for i, x in enumerate(product(range(n_bins_x), repeat=space.dim_x)):
+            for j, y in enumerate(product(range(n_bins_y), repeat=space.dim_y)):
                 index = tuple(x) + tuple(y)
                 flat_histogram[i, j] = histogram[tuple(index)]
 

--- a/src/bmi/interface.py
+++ b/src/bmi/interface.py
@@ -5,6 +5,7 @@ from typing import Any, Protocol, Union
 
 import numpy as np
 from numpy.typing import ArrayLike
+from pydantic import BaseModel
 
 # This should be updated to the PRNGKeyArray (or possibly union with Any)
 # when it becomes a part of public JAX API
@@ -26,6 +27,11 @@ class IMutualInformationPointEstimator(Protocol):
         Returns:
             mutual information estimate
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def parameters(self) -> BaseModel:
+        """Returns the parameters of the estimator."""
         raise NotImplementedError
 
 


### PR DESCRIPTION
This PR slightly refactors the code, so it's easier to use.

### Minor changes:
- [x] Add `task_params` to `TaskMetadata` and to `RunResult`. It's very convenient to have them there to plot results, rather than manually generating the database and matching by `task_id`.
- [x] Make `estimator_params` a dictionary, empty `{}` by default. Having this as `Optional[dict]`, which is `Union[dict, None]`, is just a bit cumbersome to parse afterwards.
- [x] Adjust the estimator interface to provide parameters.

This last change was requested in #35, but there is more refactoring to be done to resolve that issue. I don't want to end up with an enormous PR, though.