### PR TITLE
Silence PyType false positive

### DIFF
--- a/src/bmi/benchmark/_serialize.py
+++ b/src/bmi/benchmark/_serialize.py
@@ -3,10 +3,9 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-import pydantic
 import yaml
 
-from bmi.interface import Pathlike
+from bmi.interface import BaseModel, Pathlike
 
 _PREFIX_X: str = "X"
 _PREFIX_Y: str = "Y"
@@ -290,13 +289,11 @@ class TaskDirectory:
     def can_load(self) -> bool:
         return self.path.is_dir() and self.task_metadata.exists() and self.samples.exists()
 
-    def save(
-        self, metadata: pydantic.BaseModel, samples: pd.DataFrame, exist_ok: bool = False
-    ) -> None:
+    def save(self, metadata: BaseModel, samples: pd.DataFrame, exist_ok: bool = False) -> None:
         """Saves metadata and samples to the disk.
 
         Args:
-            metadata: pydantic BaseModel to be serialized
+            metadata: BaseModel to be serialized
             samples: pandas data frame to be saved
             exist_ok: if True and the directory already exists, it will
               overwrite its contents. If False, it will just raise an exception.

--- a/src/bmi/benchmark/core.py
+++ b/src/bmi/benchmark/core.py
@@ -5,10 +5,10 @@ import pandas as pd
 import pydantic
 
 import bmi.benchmark._serialize as se
-from bmi.interface import ISampler
+from bmi.interface import BaseModel, ISampler
 
 
-class TaskMetadata(pydantic.BaseModel):
+class TaskMetadata(BaseModel):
     task_id: str
     dim_x: int
     dim_y: int
@@ -168,7 +168,7 @@ def generate_task(
     )
 
 
-class RunResult(pydantic.BaseModel):
+class RunResult(BaseModel):
     """Class keeping the output of a single estimator run."""
 
     task_id: str

--- a/src/bmi/estimators/external/mine.py
+++ b/src/bmi/estimators/external/mine.py
@@ -10,6 +10,8 @@ from typing import Literal, Sequence
 import pydantic
 from numpy.typing import ArrayLike
 
+from bmi.interface import BaseModel
+
 try:
     # pytype: disable=import-error
     import torch
@@ -98,7 +100,7 @@ def _parse_objective_type(objective: MINEObjectiveType) -> mine.MINEObjectiveTyp
         raise ValueError("Objective type not recognized.")
 
 
-class DataParams(pydantic.BaseModel):
+class DataParams(BaseModel):
     standardize: bool = pydantic.Field(default=True)
     proportion_train: pydantic.PositiveFloat = pydantic.Field(default=1 / 3)
     proportion_valid: pydantic.PositiveFloat = pydantic.Field(default=1 / 3)
@@ -109,23 +111,23 @@ class DataParams(pydantic.BaseModel):
         return 1 - (self.proportion_train + self.proportion_valid)
 
 
-class MINESpecificParams(pydantic.BaseModel):
+class MINESpecificParams(BaseModel):
     alpha: pydantic.PositiveFloat = pydantic.Field(default=1e-2)
     objective: MINEObjectiveType = pydantic.Field(default_factory=lambda: MINEObjectiveType.MINE)
 
 
-class StatisticsNNParams(pydantic.BaseModel):
+class StatisticsNNParams(BaseModel):
     hidden_layers: list[int] = pydantic.Field(default_factory=lambda: [10, 5])
     bias: bool = pydantic.Field(default=True)
 
 
-class TrainingParams(pydantic.BaseModel):
+class TrainingParams(BaseModel):
     learning_rate: pydantic.PositiveFloat = pydantic.Field(default=1e-3)
     max_epochs: pydantic.PositiveInt = pydantic.Field(default=300)
     batch_size: pydantic.PositiveInt = pydantic.Field(default=32)
 
 
-class AllMINEParams(pydantic.BaseModel):
+class AllMINEParams(BaseModel):
     data: DataParams = pydantic.Field(default_factory=DataParams)
     mine: MINESpecificParams = pydantic.Field(default_factory=MINESpecificParams)
     statistics_nn: StatisticsNNParams = pydantic.Field(default_factory=StatisticsNNParams)

--- a/src/bmi/estimators/function_wrapper.py
+++ b/src/bmi/estimators/function_wrapper.py
@@ -2,9 +2,8 @@ from typing import Callable, Optional
 
 import numpy as np
 from numpy.typing import ArrayLike
-from pydantic import BaseModel
 
-from bmi.interface import IMutualInformationPointEstimator
+from bmi.interface import BaseModel, IMutualInformationPointEstimator
 
 
 class _EmptyParams(BaseModel):

--- a/src/bmi/estimators/histogram.py
+++ b/src/bmi/estimators/histogram.py
@@ -10,11 +10,11 @@ import numpy as np
 import pydantic
 from numpy.typing import ArrayLike
 
-from bmi.interface import IMutualInformationPointEstimator
+from bmi.interface import BaseModel, IMutualInformationPointEstimator
 from bmi.utils import ProductSpace
 
 
-class HistogramEstimatorParams(pydantic.BaseModel):
+class HistogramEstimatorParams(BaseModel):
     n_bins_x: pydantic.PositiveInt
     n_bins_y: pydantic.PositiveInt
     standardize: bool

--- a/src/bmi/interface.py
+++ b/src/bmi/interface.py
@@ -30,7 +30,9 @@ class IMutualInformationPointEstimator(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def parameters(self) -> BaseModel:
+    def parameters(self) -> BaseModel:  # pytype: disable=invalid-annotation
+        # We can remove the pytype comment once the following issue has been closed:
+        # https://github.com/google/pytype/issues/1105
         """Returns the parameters of the estimator."""
         raise NotImplementedError
 

--- a/src/bmi/interface.py
+++ b/src/bmi/interface.py
@@ -4,8 +4,20 @@ from abc import abstractmethod
 from typing import Any, Protocol, Union
 
 import numpy as np
+import pydantic
 from numpy.typing import ArrayLike
-from pydantic import BaseModel
+
+
+class BaseModel(pydantic.BaseModel):  # pytype: disable=invalid-annotation
+    """As pytype has a false-positive problem with BaseModel and our CI fails,
+    we need to create this dummy class.
+
+    We can remove it once the problem has been solved:
+    https://github.com/google/pytype/issues/1105
+    """
+
+    pass
+
 
 # This should be updated to the PRNGKeyArray (or possibly union with Any)
 # when it becomes a part of public JAX API
@@ -30,9 +42,7 @@ class IMutualInformationPointEstimator(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def parameters(self) -> BaseModel:  # pytype: disable=invalid-annotation
-        # We can remove the pytype comment once the following issue has been closed:
-        # https://github.com/google/pytype/issues/1105
+    def parameters(self) -> BaseModel:
         """Returns the parameters of the estimator."""
         raise NotImplementedError
 


### PR DESCRIPTION
PyType has a false positive, not recognizing `pydantic`'s `BaseModel` as a class, and our CI fails.

I silenced the error, we can remove this once https://github.com/google/pytype/issues/1105 has been resolved.

