### PR TITLE
Lazy loading of the benchmark tasks

### DIFF
--- a/src/bmi/benchmark/api.py
+++ b/src/bmi/benchmark/api.py
@@ -1,6 +1,6 @@
 from bmi.benchmark.core import Task, TaskMetadata, generate_task
 from bmi.benchmark.filesys.api import TaskDirectory
-from bmi.benchmark.tasks.api import BENCHMARK_TASKS, save_benchmark_tasks
+from bmi.benchmark.tasks.api import generate_benchmark, save_benchmark_tasks
 from bmi.benchmark.tasks.spiral import generate_spiral_invariance_task
 
 # ISort doesn't want to split these into several lines, conflicting with Black
@@ -29,6 +29,6 @@ __all__ = [
     "Task",
     "TaskDirectory",
     "TaskMetadata",
-    "BENCHMARK_TASKS",
+    "generate_benchmark",
     "WrappedEstimator",
 ]

--- a/src/bmi/benchmark/tasks/api.py
+++ b/src/bmi/benchmark/tasks/api.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable, Literal, Optional
 
 import bmi.benchmark.tasks.multinormal as mn
 import bmi.benchmark.tasks.spiral as spiral
@@ -7,24 +7,60 @@ import bmi.benchmark.tasks.student as st
 from bmi.benchmark.core import Task
 from bmi.interface import Pathlike
 
-BENCHMARK_TASKS = (
-    *mn.MULTINORMAL_TASKS,
-    *st.STUDENT_T_TASKS,
-)
+
+def _generate_benchmark_v1() -> Iterable[Task]:
+    # Multinormal tasks
+    yield from mn.generate_tasks()
+    # Student tasks
+    yield from st.generate_tasks()
+
+
+def generate_benchmark(version: Literal[1] = 1) -> Iterable[Task]:
+    _allowed_versions = [1]
+    _error = ValueError(
+        f"Benchmark version {version} not recognized. " f"Allowed versions: {_allowed_versions}."
+    )
+    if version not in _allowed_versions:
+        raise _error
+    if version == 1:
+        return _generate_benchmark_v1()
+    else:
+        raise _error
+
+
+def _default_naming_function(task: Task) -> str:
+    return task.task_id
 
 
 def save_benchmark_tasks(
     tasks_dir: Pathlike,
-    tasks: Iterable[Task] = BENCHMARK_TASKS,
+    tasks: Optional[Iterable[Task]] = None,
     exist_ok: bool = False,
-):
+    naming_function: Optional[Callable[[Task], str]] = None,
+) -> None:
+    """Saves given tasks.
+
+    Args:
+        tasks_dir: directory where the tasks will be saved
+        tasks: tasks to be saved. By default, version 1 of the benchmark.
+        exist_ok: if False and `tasks_dir` already exists,
+          an error will be raised
+        naming_function: function which takes a task and produces
+          the subdirectory name where the task should be saved.
+          The default is `lambda task: task.task_id`
+    """
+    if naming_function is None:
+        naming_function = _default_naming_function
+    if tasks is None:
+        tasks = generate_benchmark(version=1)
+
     for task in tasks:
-        task_dir = Path(tasks_dir) / task.task_id
+        task_dir = Path(tasks_dir) / naming_function(task)
         task.save(task_dir, exist_ok=exist_ok)
 
 
 __all__ = [
-    "BENCHMARK_TASKS",
+    "generate_benchmark",
     "save_benchmark_tasks",
     "spiral",
 ]

--- a/src/bmi/benchmark/tasks/multinormal.py
+++ b/src/bmi/benchmark/tasks/multinormal.py
@@ -1,9 +1,9 @@
-from typing import Optional
+from typing import Iterable, Optional
 
 import numpy as np
 
 import bmi.samplers.api as samplers
-from bmi.benchmark.core import generate_task
+from bmi.benchmark.core import Task, generate_task
 
 SEEDS = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
@@ -13,7 +13,7 @@ def task_mn_uniform(
     dim_y: int,
     n_samples: int,
     seeds=SEEDS,
-):
+) -> Task:
     sampler = samplers.SplitMultinormal(
         dim_x=dim_x,
         dim_y=dim_y,
@@ -38,7 +38,7 @@ def task_mn_sparse(
     correlation_noise: float = 0.1,
     seeds=SEEDS,
     task_id: Optional[str] = None,
-):
+) -> Task:
     covariance = samplers.parametrised_correlation_matrix(
         dim_x=dim_x,
         dim_y=dim_y,
@@ -68,40 +68,30 @@ def task_mn_sparse(
     return task
 
 
-# Uniform correlations
-
-task_mn_uniform_2_2 = task_mn_uniform(dim_x=2, dim_y=2, n_samples=5000)
-task_mn_uniform_2_5 = task_mn_uniform(dim_x=2, dim_y=5, n_samples=5000)
-task_mn_uniform_5_5 = task_mn_uniform(dim_x=5, dim_y=5, n_samples=5000)
-task_mn_uniform_25_25 = task_mn_uniform(dim_x=25, dim_y=25, n_samples=5000)
-task_mn_uniform_50_50 = task_mn_uniform(dim_x=50, dim_y=50, n_samples=5000)
-
-
-# Sparse correlations
-
-task_mn_sparse_3_3 = task_mn_sparse(dim_x=3, dim_y=3, n_samples=5000)
-task_mn_sparse_2_5 = task_mn_sparse(dim_x=2, dim_y=5, n_samples=5000)
-task_mn_sparse_5_5 = task_mn_sparse(dim_x=5, dim_y=5, n_samples=5000)
-task_mn_sparse_25_25 = task_mn_sparse(dim_x=25, dim_y=25, n_samples=5000)
-
-task_mn_sparse_5_5_no_noise = task_mn_sparse(
-    dim_x=5,
-    dim_y=5,
-    n_samples=5000,
-    correlation_noise=0.0,
-    task_id="mn-sparse-5-5-5000-no-noise",
-)
+def _generate_uniform_tasks() -> Iterable[Task]:
+    """Uniform correlations between all variables."""
+    yield task_mn_uniform(dim_x=2, dim_y=2, n_samples=5000)
+    yield task_mn_uniform(dim_x=2, dim_y=5, n_samples=5000)
+    yield task_mn_uniform(dim_x=5, dim_y=5, n_samples=5000)
+    yield task_mn_uniform(dim_x=25, dim_y=25, n_samples=5000)
+    yield task_mn_uniform(dim_x=50, dim_y=50, n_samples=5000)
 
 
-MULTINORMAL_TASKS = (
-    task_mn_uniform_2_2,
-    task_mn_uniform_2_5,
-    task_mn_uniform_5_5,
-    task_mn_uniform_25_25,
-    task_mn_uniform_50_50,
-    task_mn_sparse_3_3,
-    task_mn_sparse_2_5,
-    task_mn_sparse_5_5,
-    task_mn_sparse_25_25,
-    task_mn_sparse_5_5_no_noise,
-)
+def _generate_sparse_tasks() -> Iterable[Task]:
+    """Sparse correlations."""
+    yield task_mn_sparse(dim_x=3, dim_y=3, n_samples=5000)
+    yield task_mn_sparse(dim_x=2, dim_y=5, n_samples=5000)
+    yield task_mn_sparse(dim_x=5, dim_y=5, n_samples=5000)
+    yield task_mn_sparse(dim_x=25, dim_y=25, n_samples=5000)
+    yield task_mn_sparse(
+        dim_x=5,
+        dim_y=5,
+        n_samples=5000,
+        correlation_noise=0.0,
+        task_id="mn-sparse-5-5-5000-no-noise",
+    )
+
+
+def generate_tasks() -> Iterable[Task]:
+    yield from _generate_uniform_tasks()
+    yield from _generate_sparse_tasks()

--- a/src/bmi/benchmark/tasks/student.py
+++ b/src/bmi/benchmark/tasks/student.py
@@ -1,9 +1,9 @@
-from typing import Optional
+from typing import Iterable, Optional
 
 import numpy as np
 
 import bmi.samplers.api as samplers
-from bmi.benchmark.core import generate_task
+from bmi.benchmark.core import Task, generate_task
 
 SEEDS = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
@@ -14,7 +14,7 @@ def task_st_uniform(
     df: float,
     n_samples: int,
     seeds=SEEDS,
-):
+) -> Task:
     sampler = samplers.SplitStudentT(
         dim_x=dim_x,
         dim_y=dim_y,
@@ -41,7 +41,7 @@ def task_st_sparse(
     dispersion_noise: float = 0.1,
     seeds=SEEDS,
     task_id: Optional[str] = None,
-):
+) -> Task:
     dispersion = samplers.parametrised_correlation_matrix(
         dim_x=dim_x,
         dim_y=dim_y,
@@ -70,36 +70,30 @@ def task_st_sparse(
     return task
 
 
-# Uniform correlations
+def _generate_uniform() -> Iterable[Task]:
+    """Uniform dispersion matrix."""
 
-# no covariance here! let's see how this goes...
-task_st_uniform_5_5_2 = task_st_uniform(dim_x=5, dim_y=5, df=2, n_samples=5000)
+    # Covariance for df=2 doesn't exist! Let's see how this goes...
+    yield task_st_uniform(dim_x=5, dim_y=5, df=2, n_samples=5000)
 
-task_st_uniform_5_5_3 = task_st_uniform(dim_x=5, dim_y=5, df=3, n_samples=5000)
-task_st_uniform_5_5_5 = task_st_uniform(dim_x=5, dim_y=5, df=5, n_samples=5000)
-task_st_uniform_5_5_10 = task_st_uniform(dim_x=5, dim_y=5, df=10, n_samples=5000)
-task_st_uniform_5_5_30 = task_st_uniform(dim_x=5, dim_y=5, df=30, n_samples=5000)
+    # Larger df have covariance
+    yield task_st_uniform(dim_x=5, dim_y=5, df=3, n_samples=5000)
+    yield task_st_uniform(dim_x=5, dim_y=5, df=5, n_samples=5000)
+    yield task_st_uniform(dim_x=5, dim_y=5, df=10, n_samples=5000)
+    yield task_st_uniform(dim_x=5, dim_y=5, df=30, n_samples=5000)
 
-task_st_uniform_2_2_5 = task_st_uniform(dim_x=2, dim_y=2, df=5, n_samples=5000)
-task_st_uniform_25_25_5 = task_st_uniform(dim_x=25, dim_y=25, df=5, n_samples=5000)
-
-
-# Sparse correlations
-
-task_st_sparse_3_3_5 = task_st_sparse(dim_x=3, dim_y=3, df=5, n_samples=5000)
-task_st_sparse_2_5_5 = task_st_sparse(dim_x=2, dim_y=5, df=5, n_samples=5000)
-task_st_sparse_5_5_5 = task_st_sparse(dim_x=5, dim_y=5, df=5, n_samples=5000)
+    # Different dimensions with df = 5
+    yield task_st_uniform(dim_x=2, dim_y=2, df=5, n_samples=5000)
+    yield task_st_uniform(dim_x=25, dim_y=25, df=5, n_samples=5000)
 
 
-STUDENT_T_TASKS = (
-    task_st_uniform_5_5_2,
-    task_st_uniform_5_5_3,
-    task_st_uniform_5_5_5,
-    task_st_uniform_5_5_10,
-    task_st_uniform_5_5_30,
-    task_st_uniform_2_2_5,
-    task_st_uniform_25_25_5,
-    task_st_sparse_3_3_5,
-    task_st_sparse_2_5_5,
-    task_st_sparse_5_5_5,
-)
+def _generate_sparse() -> Iterable[Task]:
+    """Sparse dispersion matrix."""
+    yield task_st_sparse(dim_x=3, dim_y=3, df=5, n_samples=5000)
+    yield task_st_sparse(dim_x=2, dim_y=5, df=5, n_samples=5000)
+    yield task_st_sparse(dim_x=5, dim_y=5, df=5, n_samples=5000)
+
+
+def generate_tasks() -> Iterable[Task]:
+    yield from _generate_uniform()
+    yield from _generate_sparse()


### PR DESCRIPTION
Previously, we used to generate _all the samples_ whenever we loaded `bmi.api.benchmark`. This is 
  - slow and
  - probably takes much more memory than it should (as we define them as global constants, garbage collector probably doesn't delete them).

We fix this issue by generating the tasks inside the functions and using `yield`.

Also, we will use numbered versions of the benchmarks, so that the API in the future can stay the same.