### PR TITLE
Move from predefined estimators to configurable ones

### DIFF
--- a/scripts/figures/spiral/README.md
+++ b/scripts/figures/spiral/README.md
@@ -38,7 +38,7 @@ $ python scripts/figures/spiral/experimental_design.py $SPIRALDIR/tasks $SPIRALD
 ```
 To actually run them, we need to pipe them to GNU Parallel:
 ```
-$ python scripts/figures/spiral/run_estimators.py $SPIRALDIR/tasks $SPIRALDIR/results | parallel
+$ python scripts/figures/spiral/experimental_design.py $SPIRALDIR/tasks $SPIRALDIR/results | parallel
 ```
 Et voilà, we have all the estimators running in parallel, what is much faster than running them sequentially in Python!
 You can observe how the new results appear every second by listing the `$SPIRALDIR/results` directory.

--- a/scripts/figures/spiral/README.md
+++ b/scripts/figures/spiral/README.md
@@ -25,29 +25,34 @@ Generate the benchmark tasks:
 $ python scripts/figures/spiral/generate_spiral_tasks.py $SPIRALDIR/tasks
 ```
 
-Then, run the estimators. We'll use [GNU Parallel](https://www.gnu.org/software/parallel/) to do this.
-Let's generate the list of commands to be run:
+Then, let's run the estimators. We'll use [GNU Parallel](https://www.gnu.org/software/parallel/) to do this.
+Hence, we need to create an experimental design. For this experiment, we created one in `scripts/figures/spiral/experimental_design.py`.
+Let's take a look at it:
 ```
-$ python scripts/figures/spiral/run_estimators.py $SPIRALDIR/tasks $SPIRALDIR/results 
+$ python scripts/figures/spiral/experimental_design.py $SPIRALDIR/tasks $SPIRALDIR/results --summary
 ```
-As you can see, these commands are just printed out. To actually run them, we need to to pipe them to GNU Parallel:
+Note the `--summary` flag, so only a summary is printed, rather than all the commands running the estimators!
+To print out the commands run:
+```
+$ python scripts/figures/spiral/experimental_design.py $SPIRALDIR/tasks $SPIRALDIR/results
+```
+To actually run them, we need to pipe them to GNU Parallel:
 ```
 $ python scripts/figures/spiral/run_estimators.py $SPIRALDIR/tasks $SPIRALDIR/results | parallel
 ```
-Et voilà, we have all the estimators running in parallel, what speeds up the whole process over running them sequentially in Python!
+Et voilà, we have all the estimators running in parallel, what is much faster than running them sequentially in Python!
 You can observe how the new results appear every second by listing the `$SPIRALDIR/results` directory.
 For example, I like running:
 ```
 $ ls -1 $SPIRALDIR/results | wc -l
 ```
-to see how the results are appearing and
+and compare it to expected number of runs from the summary.
+Also, to see how many cores are used I recommend:
 ```
 $ htop
 ```
-to see how many cores are used.
 
-Once all the run has finished, you can generate the plot:
+Once all the runs have finished, you can generate the plot:
 ```
 $ python scripts/figures/spiral/plot_performance.py $SPIRALDIR/tasks $SPIRALDIR/results $SPIRALDIR/figures/spiral_plot.pdf
 ```
-

--- a/scripts/figures/spiral/experimental_design.py
+++ b/scripts/figures/spiral/experimental_design.py
@@ -8,6 +8,12 @@ def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("TASKS", type=Path, help="Directory with the tasks.")
     parser.add_argument("RESULTS", type=Path, help="Directory where the results should be dumped.")
+    parser.add_argument(
+        "--summary",
+        default=False,
+        action="store_true",
+        help="Instead of printing experimental design," "print some summary. ",
+    )
     return parser
 
 
@@ -27,10 +33,18 @@ def main() -> None:
 
     results_directory.mkdir(exist_ok=True)
 
+    # Variables for the summary
+    n_runs = 0  # Keeps the total number of runs
+    task_ids = []  # Keeps task IDs
+
     for task_path in task_directory.iterdir():
         task = bmi.benchmark.Task.load(task_path)
+        task_ids.append(task.task_id)
+
         for seed in task.keys():
             for estimator_id, estimator_args in ESTIMATORS.items():
+                n_runs += 1
+
                 # We hash task ID as it may contain spaces or other special characters, which
                 # are not bash-friendly
                 task_id_hash = str(hash(task.task_id))
@@ -44,7 +58,19 @@ def main() -> None:
                     f"--estimator-id {estimator_id} "
                     f"{estimator_args}"
                 )
-                print(command)
+                # If we just want to summarize the experimental design,
+                # we don't print out the commands
+                if not args.summary:
+                    print(command)
+
+    if args.summary:
+        print(f"Total number of runs: {n_runs}")
+        print(f"Total number of tasks: {len(task_ids)}")
+        for task_id in task_ids:
+            print(f"  {task_id}")
+        print("Estimators (ID and additional arguments):")
+        for estimator_id, estimator_args in ESTIMATORS.items():
+            print(f"  {estimator_id}: {estimator_args}")
 
 
 if __name__ == "__main__":

--- a/scripts/figures/spiral/generate_spiral_tasks.py
+++ b/scripts/figures/spiral/generate_spiral_tasks.py
@@ -9,15 +9,15 @@ import bmi.api as bmi
 def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("DIRECTORY", type=Path, help="Path to which the tasks will be dumped.")
-    parser.add_argument("--n", type=int, default=2000, help="Number of points.")
+    parser.add_argument("--n", type=int, default=5000, help="Number of points.")
     parser.add_argument("--correlation", type=float, default=0.8, help="Correlation.")
     parser.add_argument(
         "--speed",
-        metavar="N",
+        metavar="SPEED",
         type=float,
         nargs="+",
         help="List of speed parameters for the spiral diffeomorphisms.",
-        default=[1e-2, 0.1, 0.5, 1, 2, 3, 5, 7, 10],
+        default=[1e-2, 0.1, 0.5, 1, 1.5, 2, 2.5, 3],
     )
     parser.add_argument("--seed", type=int, default=10, help="Number of seeds.")
     return parser

--- a/scripts/figures/spiral/run_estimators.py
+++ b/scripts/figures/spiral/run_estimators.py
@@ -11,18 +11,13 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-ESTIMATORS = [
-    "KSG-10",
-    "KSG-5",
-    "R-KSG-10",
-    "R-KSG-5",
-    "R-LNN-10",
-    "R-LNN-5",
-    # "MINE",
-    "Histogram-3",
-    "Histogram-5",
-    "CCA",
-]
+ESTIMATORS: dict[str, str] = {
+    "KSG": "--estimator KSG --neighbors 5",
+    "LNN": "--estimator R-LNN --neighbors 5 --truncation 15",
+    "Histogram-3": "--estimator HISTOGRAM --bins-x 3",
+    "Histogram-5": "--estimator HISTOGRAM --bins-x 5",
+    "CCA": "--estimator CCA",
+}
 
 
 def main() -> None:
@@ -35,18 +30,19 @@ def main() -> None:
     for task_path in task_directory.iterdir():
         task = bmi.benchmark.Task.load(task_path)
         for seed in task.keys():
-            for estimator in ESTIMATORS:
+            for estimator_id, estimator_args in ESTIMATORS.items():
                 # We hash task ID as it may contain spaces or other special characters, which
                 # are not bash-friendly
                 task_id_hash = str(hash(task.task_id))
 
-                output_path = results_directory / f"{estimator}-{task_id_hash}-{seed}.yaml"
+                output_path = results_directory / f"{estimator_id}-{task_id_hash}-{seed}.yaml"
                 command = (
                     f"python scripts/run_estimator.py "
-                    f"--task {str(task_path)} "
-                    f"--estimator {estimator} "
-                    f"--seed {seed} "
-                    f"--output {output_path}"
+                    f"--TASK {str(task_path)} "
+                    f"--SEED {seed} "
+                    f"--OUTPUT {output_path} "
+                    f"--estimator-id {estimator_id} "
+                    f"{estimator_args}"
                 )
                 print(command)
 

--- a/scripts/run_estimator.py
+++ b/scripts/run_estimator.py
@@ -12,7 +12,7 @@ class EstimatorType(Enum):
     R_KSG = "R-KSG"
     R_LNN = "R-LNN"
     MINE = "MINE"
-    HISTOGRAM = "Histogram"
+    HISTOGRAM = "HISTOGRAM"
     CCA = "CCA"
 
 


### PR DESCRIPTION
This PR refactors the main script (`scripts/run_estimator.py`), so we can specify different estimators and their parameters. This is not the final version of this script (as we can add more estimators or allow changing MINE parameters), but it suffices to answer many interesting questions.

The script with the experimental design for the spiral experiment has been subsequently adjusted. It should be used as the starting point for new experimental designs. 