### PR TITLE
Return Axes, rather than an array

### DIFF
--- a/src/bmi/plot_utils/subplots_from_axsize.py
+++ b/src/bmi/plot_utils/subplots_from_axsize.py
@@ -93,4 +93,7 @@ def subplots_from_axsize(
     if squeeze:
         axs = np.squeeze(axs)
 
-    return fig, axs
+    if len(axs.ravel()) == 1:
+        return fig, axs.ravel()[0]
+    else:
+        return fig, axs


### PR DESCRIPTION
This PR fixes the function generating subplots, so that a single `Axes` object is returned "as is", rather than being wrapped in an array of shape `()`.